### PR TITLE
Workswitch toggles auto, moved logic to class

### DIFF
--- a/AgOpenGPS_Dev/SourceCode/GPS/Classes/CWorkSwitch.cs
+++ b/AgOpenGPS_Dev/SourceCode/GPS/Classes/CWorkSwitch.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace AgOpenGPS
+{
+    public class CWorkSwitch
+    {
+        private readonly FormGPS mf;
+        public CWorkSwitch(FormGPS _f) { mf = _f; }
+
+        private int _switchValue;
+        private int CurrentSwitchValue
+        {
+            get =>  _switchValue;
+            set
+            {
+                //compares the last recorded value to the current switch value
+                if (_switchValue != value)
+                {
+                    //records and toggles if requried
+                    _switchValue = value;
+                    WorkSwitchToggle();
+                }
+            }
+        }
+
+        //Record of the required value based on switch type
+        private int triggerValue;
+
+        //Called from "OpenGL.Designer.cs" when requied
+        public void CheckWorkSwitch()
+        {
+            //Checks the type of workswitch -> records the trigger value
+            if (mf.mc.isWorkSwitchActiveLow == true) { triggerValue = 0; }
+            else if (mf.mc.isWorkSwitchActiveLow == false) { triggerValue = 1; }
+            //Checks if swtich state has changed -> calls "set" accessor of "CurrentSwitchValue"
+            CurrentSwitchValue = mf.mc.workSwitchValue;
+
+        }
+        //Toggles the switch if state has changed
+        void WorkSwitchToggle()
+        {
+            if (CurrentSwitchValue == triggerValue)
+            {
+                //Checks current state of on-screen button -> "clicks" if required
+                if (mf.autoBtnState != FormGPS.btnStates.Auto) { mf.btnSectionOffAutoOn.PerformClick(); }
+            }
+            else
+            {
+                if (mf.autoBtnState != FormGPS.btnStates.Off) { mf.btnSectionOffAutoOn.PerformClick(); }
+            }
+        }
+    }
+}

--- a/AgOpenGPS_Dev/SourceCode/GPS/Forms/FormGPS.cs
+++ b/AgOpenGPS_Dev/SourceCode/GPS/Forms/FormGPS.cs
@@ -208,6 +208,11 @@ namespace AgOpenGPS
         /// </summary>
         public CGeoFence gf;
 
+        /// <summary>
+        /// Class containing workswitch functionality
+        /// </summary>
+        public CWorkSwitch workSwitch;
+
         #endregion // Class Props and instances
 
         // Constructor, Initializes a new instance of the "FormGPS" class.
@@ -299,6 +304,9 @@ namespace AgOpenGPS
 
             // Add Message Event handler for Form decoupling from client socket thread
             updateRTCM_DataEvent = new UpdateRTCM_Data(OnAddMessage);
+
+            // Access to workswitch functionality
+            workSwitch = new CWorkSwitch(this);
         }
 
         private void ZoomByMouseWheel(object sender, MouseEventArgs e)

--- a/AgOpenGPS_Dev/SourceCode/GPS/Forms/OpenGL.Designer.cs
+++ b/AgOpenGPS_Dev/SourceCode/GPS/Forms/OpenGL.Designer.cs
@@ -795,33 +795,11 @@ namespace AgOpenGPS
                         section[j].sectionOnRequest = false;
                         section[j].sectionOffRequest = true;
                     }
-
-                    //digital input Master control (WorkSwitch)
-                    if (isJobStarted && mc.isWorkSwitchEnabled)
-                    {
-                        //check condition of work switch
-                        if (mc.isWorkSwitchActiveLow)
-                        {
-                            if (mc.workSwitchValue == 0)
-                            { section[j].sectionOnRequest = true; section[j].sectionOffRequest = false; }
-                            else { section[j].sectionOnRequest = false; section[j].sectionOffRequest = true; }
-                        }
-                        else
-                        {
-                            if (mc.workSwitchValue == 1)
-                            { section[j].sectionOnRequest = true; section[j].sectionOffRequest = false; }
-                            else { section[j].sectionOnRequest = false; section[j].sectionOffRequest = true; }
-                        }
-                    }
                 }
             }
 
-            //double check the work switch to enable/disable auto section button
-            if (isJobStarted)
-            {
-                if (!mc.isWorkSwitchEnabled) btnSectionOffAutoOn.Enabled = true;
-                else btnSectionOffAutoOn.Enabled = false;
-            }
+        //Checks the workswitch if required
+	    if (isJobStarted && mc.isWorkSwitchEnabled) { workSwitch.CheckWorkSwitch(); }
 
             //Determine if sections want to be on or off
             ProcessSectionOnOffRequests();


### PR DESCRIPTION
Summary of alterations:
- Workswitch toggles auto instead of manual
- Workswitch logic extracted to seperate class/file
- Altered logic to be conditional
    i.e. The logic for toggling auto on/off only executes if/when the
         state of the workswitch changes
- Enabling the workswitch in the vehicle settings no longer disables
  the on-screen button
    - Cycling the workswitch will re-sync the switch and on-screen
      button to the same state (ensuring that the workswitch
      can't become inverted)

The logic regarding the workswitch has been relocated from
"OpenGL.Designer.cs" to "CWorkSwitch.cs"; where the logic in the
former resided, a method call to the latter has been implemented.
The neccessary instantiation and assignment required has been included
in "FormGPS.cs".
The toggling of the auto mode based on the work switch is undertaken
by simulating a "click" (press) of the on-screen button.

The location of the "CheckWorkSwitch()" method call in
"OpenGL.Designer.cs" is functional, but could be easily changed if a
more suitable location is evaluated. Checking of the workswitch is only
undertaken when workswitch is enabled and a job/field has been started.