### PR TITLE
Add manual control back to workswitch

### DIFF
--- a/AgOpenGPS_Dev/SourceCode/GPS/AgOpenGPS.csproj
+++ b/AgOpenGPS_Dev/SourceCode/GPS/AgOpenGPS.csproj
@@ -110,6 +110,7 @@
     <Compile Include="Classes\CMazePath.cs" />
     <Compile Include="Classes\CRecordedPath.cs" />
     <Compile Include="Classes\CSim.cs" />
+    <Compile Include="Classes\CWorkSwitch.cs" />
     <Compile Include="Classes\CYouTurn.cs" />
     <Compile Include="Classes\CBoundary.cs" />
     <Compile Include="Classes\CFlag.cs" />

--- a/AgOpenGPS_Dev/SourceCode/GPS/Classes/CModuleComm.cs
+++ b/AgOpenGPS_Dev/SourceCode/GPS/Classes/CModuleComm.cs
@@ -66,7 +66,7 @@
         public int lidarDistance;
 
         //for the workswitch
-        public bool isWorkSwitchActiveLow, isWorkSwitchEnabled;
+        public bool isWorkSwitchActiveLow, isWorkSwitchEnabled, isWorkSwitchManual;
 
         public int workSwitchValue;
 

--- a/AgOpenGPS_Dev/SourceCode/GPS/Classes/CWorkSwitch.cs
+++ b/AgOpenGPS_Dev/SourceCode/GPS/Classes/CWorkSwitch.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace AgOpenGPS
 {
@@ -10,47 +7,68 @@ namespace AgOpenGPS
         private readonly FormGPS mf;
         public CWorkSwitch(FormGPS _f) { mf = _f; }
 
-        private int _switchValue;
-        private int CurrentSwitchValue
-        {
-            get =>  _switchValue;
-            set
-            {
-                //compares the last recorded value to the current switch value
-                if (_switchValue != value)
-                {
-                    //records and toggles if requried
-                    _switchValue = value;
-                    WorkSwitchToggle();
-                }
-            }
-        }
+        //Stored copies of workswitch variables, used for comparisons
+        private bool workSwitchActiveLow;
+        private bool workSwitchManual;
+        private int workSwitchValue;
 
         //Record of the required value based on switch type
         private int triggerValue;
 
+        //Stored copies of on-screen button states (and the state required by the workswitch), used for comparisons
+        private FormGPS.btnStates autoButtonState, manualButtonState, requiredButtonState;
+        private readonly FormGPS.btnStates offButtonState = FormGPS.btnStates.Off;
+
+        //Defined in "Configure" based on the variables of the workswitch
+        private Action CheckAndToggleOn;
+
         //Called from "OpenGL.Designer.cs" when requied
         public void CheckWorkSwitch()
         {
-            //Checks the type of workswitch -> records the trigger value
-            if (mf.mc.isWorkSwitchActiveLow == true) { triggerValue = 0; }
-            else if (mf.mc.isWorkSwitchActiveLow == false) { triggerValue = 1; }
-            //Checks if swtich state has changed -> calls "set" accessor of "CurrentSwitchValue"
-            CurrentSwitchValue = mf.mc.workSwitchValue;
-
-        }
-        //Toggles the switch if state has changed
-        void WorkSwitchToggle()
-        {
-            if (CurrentSwitchValue == triggerValue)
+            if (workSwitchValue != mf.mc.workSwitchValue)
             {
-                //Checks current state of on-screen button -> "clicks" if required
-                if (mf.autoBtnState != FormGPS.btnStates.Auto) { mf.btnSectionOffAutoOn.PerformClick(); }
+                workSwitchValue = mf.mc.workSwitchValue;
+
+                if (workSwitchActiveLow != mf.mc.isWorkSwitchActiveLow) { workSwitchActiveLow = mf.mc.isWorkSwitchActiveLow; Configure(); }
+                if (workSwitchManual != mf.mc.isWorkSwitchManual) { workSwitchManual = mf.mc.isWorkSwitchManual; Configure(); }
+
+                //Forces configuration if it does not occur above
+                if (CheckAndToggleOn == null) { Configure(); }
+
+                //Keeps local copies of variables updated, important for correct comparison of button states
+                if (autoButtonState != mf.autoBtnState) { autoButtonState = mf.autoBtnState; }
+                if (manualButtonState != mf.manualBtnState) { manualButtonState = mf.manualBtnState; }
+
+                if (workSwitchValue == triggerValue) { CheckAndToggleOn(); }
+                else
+                {
+                    //Checks both on-screen buttons, performs click if button is not off
+                    if (autoButtonState != offButtonState) { mf.btnSectionOffAutoOn.PerformClick(); }
+                    if (manualButtonState != offButtonState) { mf.btnManualOffOn.PerformClick(); }
+                }
+            }
+        }
+
+        //Assigns variables based on workswitch settings
+        private void Configure()
+        {
+            if (workSwitchActiveLow == true) { triggerValue = 0; }
+            else { triggerValue = 1; }
+
+            if (workSwitchManual == false)
+            {
+                requiredButtonState = FormGPS.btnStates.Auto;
+                CheckAndToggleOn = CheckAutoButtonAndClickOn;
             }
             else
             {
-                if (mf.autoBtnState != FormGPS.btnStates.Off) { mf.btnSectionOffAutoOn.PerformClick(); }
+                requiredButtonState = FormGPS.btnStates.On;
+                CheckAndToggleOn = CheckManualButtonAndClickOn;
             }
         }
+
+        //Predefined functions, chosen based on workswitch settings
+        private void CheckAutoButtonAndClickOn() { if (autoButtonState != requiredButtonState) { mf.btnSectionOffAutoOn.PerformClick(); } }
+        private void CheckManualButtonAndClickOn() { if (manualButtonState != requiredButtonState) { mf.btnManualOffOn.PerformClick(); } }
     }
 }

--- a/AgOpenGPS_Dev/SourceCode/GPS/Forms/FormGPS.Designer.cs
+++ b/AgOpenGPS_Dev/SourceCode/GPS/Forms/FormGPS.Designer.cs
@@ -2280,7 +2280,7 @@
         private System.Windows.Forms.ToolStripMenuItem resetALLToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem loadVehicleToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem saveVehicleToolStripMenuItem;
-        private System.Windows.Forms.Button btnManualOffOn;
+        public System.Windows.Forms.Button btnManualOffOn;
         private System.Windows.Forms.Button btnSection1Man;
         private System.Windows.Forms.Button btnSection2Man;
         private System.Windows.Forms.Button btnSection3Man;

--- a/AgOpenGPS_Dev/SourceCode/GPS/Forms/FormGPS.cs
+++ b/AgOpenGPS_Dev/SourceCode/GPS/Forms/FormGPS.cs
@@ -457,6 +457,7 @@ namespace AgOpenGPS
             //workswitch stuff
             mc.isWorkSwitchEnabled = Settings.Default.setF_IsWorkSwitchEnabled;
             mc.isWorkSwitchActiveLow = Settings.Default.setF_IsWorkSwitchActiveLow;
+            mc.isWorkSwitchManual = Settings.Default.setF_IsWorkSwitchManual;
 
             minFixStepDist = Settings.Default.setF_minFixStep;
 

--- a/AgOpenGPS_Dev/SourceCode/GPS/Forms/FormSettings.Designer.cs
+++ b/AgOpenGPS_Dev/SourceCode/GPS/Forms/FormSettings.Designer.cs
@@ -109,6 +109,7 @@
             this.groupBox3 = new System.Windows.Forms.GroupBox();
             this.chkWorkSwActiveLow = new System.Windows.Forms.CheckBox();
             this.chkEnableWorkSwitch = new System.Windows.Forms.CheckBox();
+            this.checkWorkSwitchManual = new System.Windows.Forms.CheckBox();
             this.tabExamples = new System.Windows.Forms.TabPage();
             this.lblSecTotalWidthInches = new System.Windows.Forms.Label();
             this.lblSecTotalWidthFeet = new System.Windows.Forms.Label();
@@ -995,6 +996,7 @@
             // 
             // groupBox3
             // 
+            this.groupBox3.Controls.Add(this.checkWorkSwitchManual);
             this.groupBox3.Controls.Add(this.chkWorkSwActiveLow);
             this.groupBox3.Controls.Add(this.chkEnableWorkSwitch);
             resources.ApplyResources(this.groupBox3, "groupBox3");
@@ -1014,6 +1016,13 @@
             this.chkEnableWorkSwitch.Name = "chkEnableWorkSwitch";
             this.chkEnableWorkSwitch.UseVisualStyleBackColor = true;
             this.chkEnableWorkSwitch.CheckedChanged += new System.EventHandler(this.chkEnableWorkSwitch_CheckedChanged);
+            // 
+            // checkWorkSwitchManual
+            // 
+            resources.ApplyResources(this.checkWorkSwitchManual, "checkWorkSwitchManual");
+            this.checkWorkSwitchManual.Name = "checkWorkSwitchManual";
+            this.checkWorkSwitchManual.UseVisualStyleBackColor = true;
+            this.checkWorkSwitchManual.CheckedChanged += new System.EventHandler(this.checkWorkSwitchManual_CheckedChanged);
             // 
             // tabExamples
             // 
@@ -1185,6 +1194,7 @@
         private System.Windows.Forms.TabPage tabWorkSwitch;
         private System.Windows.Forms.CheckBox chkEnableWorkSwitch;
         private System.Windows.Forms.CheckBox chkWorkSwActiveLow;
+        private System.Windows.Forms.CheckBox checkWorkSwitchManual;
         private System.Windows.Forms.GroupBox groupBox3;
         private System.Windows.Forms.Label lblDoNotExceed;
         private System.Windows.Forms.NumericUpDown nudSection8;

--- a/AgOpenGPS_Dev/SourceCode/GPS/Forms/FormSettings.cs
+++ b/AgOpenGPS_Dev/SourceCode/GPS/Forms/FormSettings.cs
@@ -23,7 +23,7 @@ namespace AgOpenGPS
                         sectionPosition5, sectionPosition6, sectionPosition7, sectionPosition8, sectionPosition9,
                         sectionPosition10, sectionPosition11, sectionPosition12, sectionPosition13;
 
-        private bool isWorkSwEn, isWorkSwActiveLow;
+        private bool isWorkSwEn, isWorkSwActiveLow, isWorkSwitchManual;
 
         private readonly double metImp2m, m2MetImp, cutoffMetricImperial, maxWidth;
         private double cutoffSpeed;
@@ -273,6 +273,12 @@ namespace AgOpenGPS
             chkEnableWorkSwitch.Checked = isWorkSwEn;
             chkEnableWorkSwitch.CheckedChanged += chkEnableWorkSwitch_CheckedChanged;
 
+            isWorkSwitchManual = Properties.Settings.Default.setF_IsWorkSwitchManual;
+
+            checkWorkSwitchManual.CheckedChanged -= checkWorkSwitchManual_CheckedChanged;
+            checkWorkSwitchManual.Checked = isWorkSwitchManual;
+            checkWorkSwitchManual.CheckedChanged += checkWorkSwitchManual_CheckedChanged;
+
             nudCutoffSpeed.ValueChanged -= nudCutoffSpeed_ValueChanged;
             nudCutoffSpeed.Value = (decimal)cutoffSpeed;
             nudCutoffSpeed.ValueChanged += nudCutoffSpeed_ValueChanged;
@@ -382,6 +388,9 @@ namespace AgOpenGPS
 
             mf.mc.isWorkSwitchEnabled = isWorkSwEn;
             Properties.Settings.Default.setF_IsWorkSwitchEnabled = isWorkSwEn;
+
+            mf.mc.isWorkSwitchManual = isWorkSwitchManual;
+            Properties.Settings.Default.setF_IsWorkSwitchManual = isWorkSwitchManual;
 
             Properties.Vehicle.Default.setVehicle_slowSpeedCutoff = cutoffSpeed * cutoffMetricImperial;
             mf.vehicle.slowSpeedCutoff = cutoffSpeed * cutoffMetricImperial;
@@ -1168,6 +1177,12 @@ namespace AgOpenGPS
         {
             isWorkSwEn = !isWorkSwEn;
             chkEnableWorkSwitch.Checked = isWorkSwEn;
+        }
+
+        private void checkWorkSwitchManual_CheckedChanged(object sender, EventArgs e)
+        {
+            isWorkSwitchManual = !isWorkSwitchManual;
+            checkWorkSwitchManual.Checked = isWorkSwitchManual;
         }
 
         #endregion WorkSwitch //---------------------------------------------------------

--- a/AgOpenGPS_Dev/SourceCode/GPS/Forms/FormSettings.resx
+++ b/AgOpenGPS_Dev/SourceCode/GPS/Forms/FormSettings.resx
@@ -2406,6 +2406,33 @@ or Overlap</value>
   <data name="tabWorkSwitch.BackgroundImageLayout" type="System.Windows.Forms.ImageLayout, System.Windows.Forms">
     <value>None</value>
   </data>
+  <data name="checkWorkSwitchManual.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="checkWorkSwitchManual.Location" type="System.Drawing.Point, System.Drawing">
+    <value>46, 154</value>
+  </data>
+  <data name="checkWorkSwitchManual.Size" type="System.Drawing.Size, System.Drawing">
+    <value>363, 29</value>
+  </data>
+  <data name="checkWorkSwitchManual.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="checkWorkSwitchManual.Text" xml:space="preserve">
+    <value>Manual - Leave unchecked for Auto</value>
+  </data>
+  <data name="&gt;&gt;checkWorkSwitchManual.Name" xml:space="preserve">
+    <value>checkWorkSwitchManual</value>
+  </data>
+  <data name="&gt;&gt;checkWorkSwitchManual.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;checkWorkSwitchManual.Parent" xml:space="preserve">
+    <value>groupBox3</value>
+  </data>
+  <data name="&gt;&gt;checkWorkSwitchManual.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="chkWorkSwActiveLow.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -2437,7 +2464,7 @@ or Overlap</value>
     <value>groupBox3</value>
   </data>
   <data name="&gt;&gt;chkWorkSwActiveLow.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="chkEnableWorkSwitch.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2470,7 +2497,7 @@ or Overlap</value>
     <value>groupBox3</value>
   </data>
   <data name="&gt;&gt;chkEnableWorkSwitch.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="groupBox3.Font" type="System.Drawing.Font, System.Drawing">
     <value>Tahoma, 15.75pt</value>
@@ -2479,7 +2506,7 @@ or Overlap</value>
     <value>454, 27</value>
   </data>
   <data name="groupBox3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>466, 158</value>
+    <value>466, 200</value>
   </data>
   <data name="groupBox3.TabIndex" type="System.Int32, mscorlib">
     <value>66</value>

--- a/AgOpenGPS_Dev/SourceCode/GPS/Forms/SaveOpen.Designer.cs
+++ b/AgOpenGPS_Dev/SourceCode/GPS/Forms/SaveOpen.Designer.cs
@@ -82,6 +82,7 @@ namespace AgOpenGPS
 
                     writer.WriteLine("WorkSwitch," + Properties.Settings.Default.setF_IsWorkSwitchEnabled.ToString(CultureInfo.InvariantCulture));
                     writer.WriteLine("ActiveLow," + Properties.Settings.Default.setF_IsWorkSwitchActiveLow.ToString(CultureInfo.InvariantCulture));
+                    writer.WriteLine("SwitchManual," + Properties.Settings.Default.setF_IsWorkSwitchManual.ToString(CultureInfo.InvariantCulture));
 
                     writer.WriteLine("CamPitch," + Properties.Settings.Default.setCam_pitch.ToString(CultureInfo.InvariantCulture));
 
@@ -294,6 +295,8 @@ namespace AgOpenGPS
                         Properties.Settings.Default.setF_IsWorkSwitchEnabled = bool.Parse(words[1]);
                         line = reader.ReadLine(); words = line.Split(',');
                         Properties.Settings.Default.setF_IsWorkSwitchActiveLow = bool.Parse(words[1]);
+                        line = reader.ReadLine(); words = line.Split(',');
+                        Properties.Settings.Default.setF_IsWorkSwitchManual = bool.Parse(words[1]);
 
                         line = reader.ReadLine(); words = line.Split(',');
                         Properties.Settings.Default.setCam_pitch = double.Parse(words[1], CultureInfo.InvariantCulture);
@@ -477,6 +480,7 @@ namespace AgOpenGPS
 
                         mc.isWorkSwitchEnabled = Properties.Settings.Default.setF_IsWorkSwitchEnabled;
                         mc.isWorkSwitchActiveLow = Properties.Settings.Default.setF_IsWorkSwitchActiveLow;
+                        mc.isWorkSwitchManual = Properties.Settings.Default.setF_IsWorkSwitchManual;
 
                         //Set width of section and positions for each section
                         SectionSetPosition();

--- a/AgOpenGPS_Dev/SourceCode/GPS/Properties/Settings.Designer.cs
+++ b/AgOpenGPS_Dev/SourceCode/GPS/Properties/Settings.Designer.cs
@@ -1042,5 +1042,17 @@ namespace AgOpenGPS.Properties {
                 this["setNTRIP_isGGAManual"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool setF_IsWorkSwitchManual {
+            get {
+                return ((bool)(this["setF_IsWorkSwitchManual"]));
+            }
+            set {
+                this["setF_IsWorkSwitchManual"] = value;
+            }
+        }
     }
 }

--- a/AgOpenGPS_Dev/SourceCode/GPS/Properties/Settings.settings
+++ b/AgOpenGPS_Dev/SourceCode/GPS/Properties/Settings.settings
@@ -257,5 +257,8 @@
     <Setting Name="setNTRIP_isGGAManual" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="setF_IsWorkSwitchManual" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>


### PR DESCRIPTION
The workswitch has the ability to control manual again. An option under
workswitch settings has be added to facilitate this.

The "CWorkswitch" file has been rewritten to allow for this
functionality and to improve clarity.