### PR TITLE
Support for SkyTraQ dual antenna setup

### DIFF
--- a/SourceCode/GPS/Classes/CNMEA.cs
+++ b/SourceCode/GPS/Classes/CNMEA.cs
@@ -628,9 +628,7 @@ Field	Meaning
 
             //update the watchdog
             mf.recvCounter = 0;
-            updatedOGI = true;
-
-            AverageTheSpeed();
+            //updatedOGI = true; //I'm not sure what this is for...
             
             /*
             $PSTI,032,033010.000,111219,A,R,‐4.968,‐10.817,‐1.849,12.046,204.67,,,,,*39

--- a/SourceCode/GPS/Classes/CNMEA.cs
+++ b/SourceCode/GPS/Classes/CNMEA.cs
@@ -156,6 +156,9 @@ Field	Meaning
         public double altitude, speed;
 
         public double headingTrue, headingHDT, hdop, ageDiff;
+        
+        //BaselinaData
+        public double eastProjection, northProjection, upProjection, baselineLength, baselineCourse;
 
         //imu
         public double nRoll, nPitch, nYaw, nAngularVelocity;
@@ -296,6 +299,7 @@ Field	Meaning
                 if (words[0] == "$PAOGI") ParseOGI();
                 if (words[0] == "$PTNL") ParseAVR();
                 if (words[0] == "$GNTRA") ParseTRA();
+                if (words[0] == "$PSTI" || words[1] == "032") ParseSTI32(); //SkyTraq Receiver RTK Baseline Data for Moving Base Dual GPS setup
 
             }// while still data
         }
@@ -584,6 +588,44 @@ Field	Meaning
                 * CHKSUM
                 */
             }
+        }
+        
+        private void ParseSTI32()
+        {
+            //Dual antenna derived heading
+            double.TryParse(words[10], NumberStyles.Float, CultureInfo.InvariantCulture, out baselineCourse);
+            headingHDT = baselineCourse - 90;
+            if (headingHDT < 0) 
+            {
+                headingHDT = 360 + headingHDT;
+            }
+            
+            //roll
+            //double.TryParse(words[6], NumberStyles.Float, CultureInfo.InvariantCulture, out eastProjection);
+            //double.TryParse(words[7], NumberStyles.Float, CultureInfo.InvariantCulture, out northProjection);
+            double.TryParse(words[8], NumberStyles.Float, CultureInfo.InvariantCulture, out upProjection);
+            double.TryParse(words[9], NumberStyles.Float, CultureInfo.InvariantCulture, out baselineLength);
+            nRoll = Math.Atan(upProjection / baselineLength) * 180 / Math.PI);
+            
+            /*
+            $PSTI
+            (1) 032 Baseline Data indicator
+            (2) UTC time hhmmss.sss
+            (3) UTC date ddmmyy
+            (4) Status:
+                V = Void
+                A = Active
+            (5) Mode Indicator:
+                F = Float RTK
+                R = fixed RTK
+            (6) East-projection of baseline, meters
+            (7) North-projection of baseline, meters
+            (8) Up-projection of baseline, meters
+            (9) Baseline length, meters
+            (10) Baseline course: angle between baseline vector and north direction, degrees
+            (11) - (15) Reserved
+            (16) Checksum
+            */
         }
 
         private void ParseVTG()

--- a/SourceCode/GPS/Classes/CNMEA.cs
+++ b/SourceCode/GPS/Classes/CNMEA.cs
@@ -592,21 +592,21 @@ Field	Meaning
         
         private void ParseSTI32()
         {
-            //ToDo: witch antenna left/right? --> rover/moving base
+            //Rover Antenna on the left, "Moving Base" on the right
             //Dual antenna derived heading
             double.TryParse(words[10], NumberStyles.Float, CultureInfo.InvariantCulture, out baselineCourse);
-            headingHDT = baselineCourse - 90;
+            headingHDT = baselineCourse - 270; //correction else driving to the north would display 270 deg (=west)
             if (headingHDT < 0) 
             {
                 headingHDT = 360 + headingHDT;
             }
             
-            //roll
-            //double.TryParse(words[6], NumberStyles.Float, CultureInfo.InvariantCulture, out eastProjection);
+            //roll from dual antenna setup
+            //double.TryParse(words[6], NumberStyles.Float, CultureInfo.InvariantCulture, out eastProjection); //could be used to calculate heading by hand
             //double.TryParse(words[7], NumberStyles.Float, CultureInfo.InvariantCulture, out northProjection);
-            double.TryParse(words[8], NumberStyles.Float, CultureInfo.InvariantCulture, out upProjection);
-            double.TryParse(words[9], NumberStyles.Float, CultureInfo.InvariantCulture, out baselineLength);
-            nRoll = Math.Atan(upProjection / baselineLength) * 180 / Math.PI);
+            double.TryParse(words[8], NumberStyles.Float, CultureInfo.InvariantCulture, out upProjection); //difference in hight of both antennas (rover - moving base)
+            double.TryParse(words[9], NumberStyles.Float, CultureInfo.InvariantCulture, out baselineLength); //length of baseline
+            nRoll = Math.Atan(upProjection / baselineLength) * 180 / Math.PI; //roll to the right = positiv (rover left, base right!)
             
             //copied from ParseOGI():
             //used only for sidehill correction - position is compensated in Lat/Lon of Dual module (???) position needs to be corrected by antenna offset!
@@ -633,7 +633,7 @@ Field	Meaning
             AverageTheSpeed();
             
             /*
-            $PSTI
+            $PSTI,032,033010.000,111219,A,R,‐4.968,‐10.817,‐1.849,12.046,204.67,,,,,*39
             (1) 032 Baseline Data indicator
             (2) UTC time hhmmss.sss
             (3) UTC date ddmmyy


### PR DESCRIPTION
With these additions I think it should be possible to use the SkyTraQ-GNSS-Receivers I like to use in Rover/"Moving Base" mode for heading and roll if they are arranged next to each other using Baseline Data output "$PSTI" in NMEA data stream. I'm not able to test this, as I don't have my hardware yet :(  (and actually at the moment don't know how to build the programm in github...)
This way it should also be possible to implement dual-antenna support for example the ublox receivers I think. It would be nice for future understanding of the code to change "mf.ahrs.isRollFromOGI" to ...isRollFromDAnt ("FromDualAntenna") or something... Also I don't understand what the variable updatedOGI is for...
Datasheet of one SkyTraQ-Receiver: http://navspark.mybigcommerce.com/content/PX1122R_DS.pdf with NMEA Output Description (important parts for this also copied to the code)

ToDo (optional): correction of the antenna position by half the baseline length: at the moment this has to be done manually with antenna offset.

PS: I really have to thank you for developing this outstanding program!