### PR TITLE
Dual antenna support for SkyTraQ receivers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -356,3 +356,4 @@ Application/
 AgOpenGPS/
 Installer/
 Program/
+/ProgramV4

--- a/SourceCode/GPS/Classes/CNMEA.cs
+++ b/SourceCode/GPS/Classes/CNMEA.cs
@@ -158,7 +158,7 @@ Field	Meaning
         public double headingTrue, headingHDT, hdop, ageDiff;
 
         //BaselineData
-        public double eastProjection, northProjection, upProjection, baselineLength, baselineCourse;
+        public double upProjection, baselineLength, baselineCourse;
 
         //imu
         public double nRoll, nPitch, nYaw, nAngularVelocity;

--- a/SourceCode/GPS/Classes/CNMEA.cs
+++ b/SourceCode/GPS/Classes/CNMEA.cs
@@ -653,16 +653,16 @@ Field	Meaning
             {
             if (!String.IsNullOrEmpty(words[10]))
                 {
-                //baselineCourse: angle between baseline vector (from "moving base" to rover) and north direction, degrees
+                //baselineCourse: angle between baseline vector (from kinematic base to rover) and north direction, degrees
                 double.TryParse(words[10], NumberStyles.Float, CultureInfo.InvariantCulture, out baselineCourse);
-                headingHDT = (baselineCourse < 270) ? (double)(baselineCourse + 90) : (double)(baselineCourse - 270); //Rover Antenna on the left, "Moving Base" on the right!!!
+                headingHDT = (baselineCourse < 270) ? (double)(baselineCourse + 90) : (double)(baselineCourse - 270); //Rover Antenna on the left, kinematic base on the right!!!
             }
 
             if (!String.IsNullOrEmpty(words[8]) && !String.IsNullOrEmpty(words[9]))
                 {
-                double.TryParse(words[8], NumberStyles.Float, CultureInfo.InvariantCulture, out upProjection); //difference in hight of both antennas (rover - moving base)
-                double.TryParse(words[9], NumberStyles.Float, CultureInfo.InvariantCulture, out baselineLength); //distance between "moving base" and rover
-                nRoll = Math.Atan(upProjection / baselineLength) * 180 / Math.PI; //roll to the right is positiv (rover left, "moving base" right!)
+                double.TryParse(words[8], NumberStyles.Float, CultureInfo.InvariantCulture, out upProjection); //difference in hight of both antennas (rover - kinematic base)
+                double.TryParse(words[9], NumberStyles.Float, CultureInfo.InvariantCulture, out baselineLength); //distance between kinematic base and rover
+                nRoll = Math.Atan(upProjection / baselineLength) * 180 / Math.PI; //roll to the right is positiv (rover left, kinematic base right!)
 
                 if (mf.ahrs.isRollFromGPS)
                 //input to the kalman filter

--- a/SourceCode/GPS/Classes/CNMEA.cs
+++ b/SourceCode/GPS/Classes/CNMEA.cs
@@ -157,6 +157,9 @@ Field	Meaning
 
         public double headingTrue, headingHDT, hdop, ageDiff;
 
+        //BaselineData
+        public double eastProjection, northProjection, upProjection, baselineLength, baselineCourse;
+
         //imu
         public double nRoll, nPitch, nYaw, nAngularVelocity;
 
@@ -296,6 +299,7 @@ Field	Meaning
                 if (words[0] == "$PAOGI") ParseOGI();
                 if (words[0] == "$PTNL") ParseAVR();
                 if (words[0] == "$GNTRA") ParseTRA();
+                if (words[0] == "$PSTI" && words[1] == "032") ParseSTI032(); //there is also an $PSTI,030,... wich contains different data!
 
             }// while still data
         }
@@ -643,6 +647,60 @@ Field	Meaning
 
                 mf.ahrs.rollX16 = mf.ahrs.isRollFromGPS ? (int)(nRoll * 16) : 0;
             }
+        }
+
+        private void ParseSTI032() //heading and roll from SkyTraQ receiver
+            {
+            if (!String.IsNullOrEmpty(words[10]))
+                {
+                //baselineCourse: angle between baseline vector (from "moving base" to rover) and north direction, degrees
+                double.TryParse(words[10], NumberStyles.Float, CultureInfo.InvariantCulture, out baselineCourse);
+                headingHDT = (baselineCourse < 270) ? (double)(baselineCourse + 90) : (double)(baselineCourse - 270); //Rover Antenna on the left, "Moving Base" on the right!!!
+            }
+
+            if (!String.IsNullOrEmpty(words[8]) && !String.IsNullOrEmpty(words[9]))
+                {
+                double.TryParse(words[8], NumberStyles.Float, CultureInfo.InvariantCulture, out upProjection); //difference in hight of both antennas (rover - moving base)
+                double.TryParse(words[9], NumberStyles.Float, CultureInfo.InvariantCulture, out baselineLength); //distance between "moving base" and rover
+                nRoll = Math.Atan(upProjection / baselineLength) * 180 / Math.PI; //roll to the right is positiv (rover left, "moving base" right!)
+
+                if (mf.ahrs.isRollFromGPS)
+                //input to the kalman filter
+                {
+                    rollK = nRoll;
+
+                    //Kalman filter
+                    Pc = P + varProcess;
+                    G = Pc / (Pc + varRoll);
+                    P = (1 - G) * Pc;
+                    Xp = XeRoll;
+                    Zp = Xp;
+                    XeRoll = (G * (rollK - Zp)) + Xp;
+
+                    mf.ahrs.rollX16 = (int)(XeRoll * 16);
+                }
+                else mf.ahrs.rollX16 = 0;
+            }
+
+            /*
+            $PSTI,032,033010.000,111219,A,R,‐4.968,‐10.817,‐1.849,12.046,204.67,,,,,*39
+            (1) 032 Baseline Data indicator
+            (2) UTC time hhmmss.sss
+            (3) UTC date ddmmyy
+            (4) Status:
+                V = Void
+                A = Active
+            (5) Mode Indicator:
+                F = Float RTK
+                R = fixed RTK
+            (6) East-projection of baseline, meters
+            (7) North-projection of baseline, meters
+            (8) Up-projection of baseline, meters
+            (9) Baseline length, meters
+            (10) Baseline course: angle between baseline vector and north direction, degrees
+            (11) - (15) Reserved
+            (16) * Checksum
+            */
         }
 
         private void ParseRMC()


### PR DESCRIPTION
I added parsing of $PSTI,032,... messages sent from SkyTraQ receivers (for example PX1122R http://navspark.mybigcommerce.com/ns-hp-gn2-px1122r-breakout-board/) in Moving Base mode.

I already tested it on my work desk and I got some good looking data for roll and heading. Further tests on field I can do when my whole setup is done in late summer or maybe even later...

One receiver starts from 99$ (125$ as breakout board) and supports GPS L1/L2C, Galileo E1/E5b, Beidou B1I/B2I and GLONASS L1/L2. RTCM3/SkyTraQRawData input/output and NMEA output. This might get an alternative for the rtksimpleBoards for some others as well I think...
I added the datasheet from the receiver below.

THiamu
[PX1122R_DS.pdf](https://github.com/farmerbriantee/AgOpenGPS/files/4422703/PX1122R_DS.pdf)
