### PR TITLE
Dynamic U-turns

### DIFF
--- a/SourceCode/GPS/AgOpenGPS.csproj
+++ b/SourceCode/GPS/AgOpenGPS.csproj
@@ -145,6 +145,8 @@
     <Compile Include="Classes\CTurn.cs" />
     <Compile Include="Classes\CTurnLines.cs" />
     <Compile Include="Classes\CTool.cs" />
+    <Compile Include="Classes\Geometrics.cs" />
+    <Compile Include="Classes\Utility.cs" />
     <Compile Include="Forms\Pickers\FormColorPicker.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/SourceCode/GPS/Classes/CYouTurn.cs
+++ b/SourceCode/GPS/Classes/CYouTurn.cs
@@ -1889,6 +1889,7 @@ namespace AgOpenGPS
 
             Intersect[][] ABTL_Intersect = new Intersect[2][]
             { new Intersect[2], new Intersect[2] };
+            int DRIVEAROUND = 0;
             {
                 Intersect[][][] intersect = new Intersect[2][][];
                 {
@@ -2127,6 +2128,85 @@ namespace AgOpenGPS
                         else iterator = -1;
                     }
                 }
+
+                int maxIndex = mf.turn.turnArr
+                            [lineIndex].turnLine.Count - 1;
+
+                int[][] index = new int[2][];
+                {
+                    int start = 0;
+                    int endIndex = 0;
+                    {
+                        if (iterator == 1)
+                        {
+                            start = ABTL_Intersect[0][0].pointIndex[0];
+                            endIndex = 1;
+                        }
+                        else if (iterator == -1)
+                        {
+                            start = ABTL_Intersect[0][0].pointIndex[1];
+                            endIndex = 0;
+                        }
+                    }
+
+                    int min = int.MaxValue;
+
+                    for (int i = 0; i < 2; i++)
+                    {
+                        for (int j = 0; j < intersect[i].Length; j++)
+                        {
+                            int k;
+                            if (i == 0 && j == 0) k = 1;
+                            else k = 0;
+
+                            for (; k < 2; k++)
+                            {
+                                int count = 0;
+                                int pointer = start;
+
+                                int end;
+                                {
+                                    if (intersect[i][j][k].lineIndex
+                                        != lineIndex) continue;
+                                    else end = intersect[i][j][k]
+                                                .pointIndex[endIndex];
+                                }
+
+                                while (pointer != end)
+                                {
+                                    if (pointer == maxIndex && iterator == 1)
+                                    {
+                                        pointer = 0;
+                                    }
+                                    else if (pointer == 0 && iterator == -1)
+                                    {
+                                        pointer = maxIndex;
+                                    }
+                                    else pointer += iterator;
+
+                                    count++;
+                                }
+
+                                if (count < min)
+                                {
+                                    min = count;
+
+                                    index[0] = new int[2]
+                                    { i, j };
+
+                                    index[1] = new int[3]
+                                    { start, end, count };
+                                }
+                            }
+                        }
+                    }
+
+                    if (min == int.MaxValue) return false;
+                }
+
+                ABTL_Intersect[1] = intersect[index[0][0]][index[0][1]];
+
+                if (index[0][0] == 0) DRIVEAROUND = 1;
             }
 
             return false;

--- a/SourceCode/GPS/Classes/CYouTurn.cs
+++ b/SourceCode/GPS/Classes/CYouTurn.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 
+using static AgOpenGPS.Utility;
 using static AgOpenGPS.Geometrics;
 
 namespace AgOpenGPS
@@ -2076,6 +2077,55 @@ namespace AgOpenGPS
                         output[i] = input[order[i]];
 
                     return 1;
+                }
+
+                int lineIndex = ABTL_Intersect[0][0].lineIndex;
+
+                int iterator = 0;
+                {
+                    double[] angle;
+                    {
+                        int[] pointIndex = ABTL_Intersect[0][0].pointIndex;
+
+                        vec2[] TLPoint = new vec2[]
+                        {
+                            new vec2
+                            (mf.turn.turnArr[lineIndex]
+                             .turnLine[pointIndex[0]].easting,
+                             mf.turn.turnArr[lineIndex]
+                             .turnLine[pointIndex[0]].northing),
+                            new vec2
+                            (mf.turn.turnArr[lineIndex]
+                             .turnLine[pointIndex[1]].easting,
+                             mf.turn.turnArr[lineIndex]
+                             .turnLine[pointIndex[1]].northing)
+                        };
+
+                        angle = new double[2]
+                        {
+                            CheckAngle(Math.Atan2
+                            (TLPoint[1].easting - TLPoint[0].easting,
+                             TLPoint[1].northing - TLPoint[0].northing)),
+                            CheckAngle(Math.Atan2
+                            (TLPoint[0].easting - TLPoint[1].easting,
+                             TLPoint[0].northing - TLPoint[1].northing))
+                        };
+                    }
+
+                    if ((config & FLAGS.left) == FLAGS.left)
+                    {
+                        if (RelativeAngle_L(heading.direction, angle[0])
+                            < RelativeAngle_L(heading.direction, angle[1]))
+                            iterator = 1;
+                        else iterator = -1;
+                    }
+                    else if ((config & FLAGS.right) == FLAGS.right)
+                    {
+                        if (RelativeAngle_R(heading.direction, angle[0])
+                            > RelativeAngle_R(heading.direction, angle[1]))
+                            iterator = 1;
+                        else iterator = -1;
+                    }
                 }
             }
 

--- a/SourceCode/GPS/Classes/CYouTurn.cs
+++ b/SourceCode/GPS/Classes/CYouTurn.cs
@@ -1858,5 +1858,68 @@ namespace AgOpenGPS
                 }
             }
         }
+
+        static byte
+        GetConfig(Inputs p_inputs, bool p_turnRight)
+        {
+            byte
+            config = 0;
+
+            double w = (p_inputs.width - p_inputs.overlap) * p_inputs.skips;
+
+            if (p_turnRight)
+            {
+                config |= FLAGS.right;
+                w -= (2 * p_inputs.offset);
+            }
+            else
+            {
+                config |= FLAGS.left;
+                w += (2 * p_inputs.offset);
+            }
+
+            if ((2 * p_inputs.radius) > w)
+                config |= FLAGS.omega;
+
+            if (p_inputs.skips > 1) config |= FLAGS.skip;
+
+            if (p_inputs.offset != 0D)
+                config |= FLAGS.offset;
+
+            return config;
+        }
+
+        private struct
+        Inputs
+        {
+            public readonly double
+            width, overlap, offset, radius;
+
+            public readonly int
+            skips;
+
+            public
+            Inputs(double width, double overlap,
+                   double offset, double radius,
+                   int skips)
+            {
+                this.width = width;
+                this.overlap = overlap;
+                this.offset = offset;
+                this.radius = radius;
+                this.skips = skips;
+            }
+        }
+
+        private struct
+        FLAGS
+        {
+            public const byte
+            left = 0x01,
+            right = 0x02,
+            omega = 0x04,
+            skip = 0x08,
+            offset = 0x10;
+        }
     }
 }

--- a/SourceCode/GPS/Classes/CYouTurn.cs
+++ b/SourceCode/GPS/Classes/CYouTurn.cs
@@ -4,6 +4,8 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 
+using static AgOpenGPS.Geometrics;
+
 namespace AgOpenGPS
 {
     public class CYouTurn
@@ -1920,6 +1922,70 @@ namespace AgOpenGPS
             omega = 0x04,
             skip = 0x08,
             offset = 0x10;
+        }
+
+        private struct
+        Intersect
+        {
+            public readonly vec2 point;
+            public readonly int lineIndex;
+            public readonly int[] pointIndex;
+
+            public
+            Intersect(vec2 p_point, int p_lineIndex, int[] p_pointIndex)
+            {
+                point = p_point;
+                lineIndex = p_lineIndex;
+                pointIndex = p_pointIndex;
+            }
+        }
+
+        private int
+        TurnLineIntersects(Ray2 ray, out Intersect[] intersects)
+        {
+            int status = -1;
+
+            List<Intersect> intersectsList = new List<Intersect>();
+
+            for (int i = 0; i < mf.turn.turnArr.Count; i++)
+            {
+                ref List<vec3> tL = ref mf.turn.turnArr[i].turnLine;
+
+                for (int j = 1; j < mf.turn.turnArr[i].turnLine.Count; j++)
+                {
+                    LineSegment2 line = new LineSegment2
+                        (new vec2(tL[j - 1].easting, tL[j - 1].northing),
+                         new vec2(tL[j].easting, tL[j].northing));
+
+                    if ((status = Intersect
+                         (ray, line, out vec2 intersect)) == 1)
+                    {
+                        intersectsList.Add
+                        (new Intersect(intersect, i, new int[] {j - 1, j}));
+                    }
+                }
+
+                {
+                    int max = tL.Count - 1;
+
+                    LineSegment2 line = new LineSegment2
+                        (new vec2(tL[max].easting, tL[max].northing),
+                         new vec2(tL[0].easting, tL[0].northing));
+
+                    if ((status = Intersect
+                         (ray, line, out vec2 intersect)) == 1)
+                    {
+                        intersectsList.Add
+                        (new Intersect(intersect, i, new int[] { max, 0 }));
+                    }
+                }
+            }
+
+            if (intersectsList.Count > 0) status = 1;
+
+            intersects = intersectsList.ToArray();
+
+            return status;
         }
     }
 }

--- a/SourceCode/GPS/Classes/CYouTurn.cs
+++ b/SourceCode/GPS/Classes/CYouTurn.cs
@@ -1861,6 +1861,34 @@ namespace AgOpenGPS
             }
         }
 
+        public bool
+        BuildABLineDynamic()
+        {
+            Inputs inputs = new Inputs
+                (mf.tool.toolWidth, mf.tool.toolOverlap,
+                 mf.tool.toolOffset, mf.vehicle.minTurningRadius,
+                 rowSkipsWidth);
+
+            byte config = GetConfig(inputs, isYouTurnRight);
+
+            vec2 currentPosition = new vec2
+                (mf.ABLine.rEastAB, mf.ABLine.rNorthAB);
+
+            Vector2 heading;
+            {
+                double direction = 0D;
+                {
+                    if (mf.ABLine.isABSameAsVehicleHeading)
+                        direction = mf.ABLine.abHeading;
+                    else direction = mf.ABLine.abHeading + Math.PI;
+                }
+
+                heading = Vector2.Polar(1D, direction);
+            }
+
+            return false;
+        }
+
         static byte
         GetConfig(Inputs p_inputs, bool p_turnRight)
         {

--- a/SourceCode/GPS/Classes/CYouTurn.cs
+++ b/SourceCode/GPS/Classes/CYouTurn.cs
@@ -2262,6 +2262,19 @@ namespace AgOpenGPS
                 }
             }
 
+            {
+                for (int i = 0; i < 2; i++)
+                {
+                    double distance = Math.Sqrt
+                        (Math.Pow(ABTL_Intersect[i][0].point.easting
+                                  - ABTL_Intersect[i][1].point.easting, 2)
+                         + Math.Pow(ABTL_Intersect[i][0].point.northing
+                                    - ABTL_Intersect[i][1].point.northing, 2));
+
+                    if (distance < (inputs.radius * 2)) return false;
+                }
+            }
+
             vec2[][] arcPoint = new vec2[2][];
             int[] segmentIndex = new int[2];
             {

--- a/SourceCode/GPS/Classes/CYouTurn.cs
+++ b/SourceCode/GPS/Classes/CYouTurn.cs
@@ -1890,6 +1890,7 @@ namespace AgOpenGPS
             Intersect[][] ABTL_Intersect = new Intersect[2][]
             { new Intersect[2], new Intersect[2] };
             int DRIVEAROUND = 0;
+            LineSegment2[] TL_Segment;
             {
                 Intersect[][][] intersect = new Intersect[2][][];
                 {
@@ -2207,6 +2208,52 @@ namespace AgOpenGPS
                 ABTL_Intersect[1] = intersect[index[0][0]][index[0][1]];
 
                 if (index[0][0] == 0) DRIVEAROUND = 1;
+
+                TL_Segment = new LineSegment2[index[1][2]];
+                {
+                    ref List<vec3>
+                    TL = ref mf.turn.turnArr[lineIndex].turnLine;
+
+                    int i = 0;
+                    int pointer = index[1][0];
+                    int end = index[1][1];
+
+                    while (pointer != end)
+                    {
+                        if (pointer == maxIndex && iterator == 1)
+                        {
+                            TL_Segment[i] = new LineSegment2
+                            (new vec2(TL[pointer].easting,
+                                      TL[pointer].northing),
+                             new vec2(TL[0].easting,
+                                      TL[0].northing));
+
+                            pointer = 0;
+                        }
+                        else if (pointer == 0 && iterator == -1)
+                        {
+                            TL_Segment[i] = new LineSegment2
+                            (new vec2(TL[pointer].easting,
+                                      TL[pointer].northing),
+                             new vec2(TL[maxIndex].easting,
+                                      TL[maxIndex].northing));
+
+                            pointer = maxIndex;
+                        }
+                        else
+                        {
+                            TL_Segment[i] = new LineSegment2
+                                (new vec2(TL[pointer].easting,
+                                          TL[pointer].northing),
+                                 new vec2(TL[pointer + iterator].easting,
+                                          TL[pointer + iterator].northing));
+
+                            pointer += iterator;
+                        }
+
+                        i++;
+                    }
+                }
             }
 
             return false;

--- a/SourceCode/GPS/Classes/CYouTurn.cs
+++ b/SourceCode/GPS/Classes/CYouTurn.cs
@@ -2868,6 +2868,45 @@ namespace AgOpenGPS
                 }
             }
 
+            {
+                vec2[] completePath = new vec2
+                    [path[0].Length + path[1].Length + path[2].Length];
+                {
+                    Array.Copy
+                        (path[0], completePath, path[0].Length);
+                    Array.Copy
+                        (path[1], 0, completePath,
+                         path[0].Length, path[1].Length);
+                    Array.Copy
+                        (path[2], 0, completePath,
+                         path[0].Length + path[1].Length, path[2].Length);
+                }
+
+                for (int i = 1; i < completePath.Length; i++)
+                {
+                    double direction = CheckAngle(Math.Atan2
+                        (completePath[i].easting
+                          - completePath[i - 1].easting,
+                         completePath[i].northing
+                          - completePath[i - 1].northing));
+
+                    ytList.Add(new vec3(completePath[i - 1].easting,
+                                        completePath[i - 1].northing,
+                                        direction));
+                }
+
+                ytList.Add(new vec3
+                    (completePath[completePath.Length - 1].easting,
+                     completePath[completePath.Length - 1].northing,
+                     Vector2.Reverse(heading).direction));
+            }
+
+            if (ytList.Count > 0)
+            {
+                youTurnPhase = 3;
+                return true;
+            }
+
             return false;
         }
 

--- a/SourceCode/GPS/Classes/CYouTurn.cs
+++ b/SourceCode/GPS/Classes/CYouTurn.cs
@@ -1872,6 +1872,12 @@ namespace AgOpenGPS
 
             byte config = GetConfig(inputs, isYouTurnRight);
 
+            if ((config & FLAGS.skip) == FLAGS.skip
+                && (config & FLAGS.offset) == FLAGS.offset)
+            {
+                if ((inputs.skips & 1) != 1) return false;
+            }
+
             vec2 currentPosition = new vec2
                 (mf.ABLine.rEastAB, mf.ABLine.rNorthAB);
 

--- a/SourceCode/GPS/Classes/Geometrics.cs
+++ b/SourceCode/GPS/Classes/Geometrics.cs
@@ -1,0 +1,393 @@
+using System;
+
+namespace AgOpenGPS
+{
+    public static class Geometrics
+    {
+        /*
+        *  Geometric vector defined in two dimensions.
+        *  Defined in terms of cartesian x,y change
+        *  and polar magnitude and direction.
+        */
+        public struct
+        Vector2
+        {
+            public readonly double x;
+            public readonly double y;
+            public readonly double magnitude;
+            public readonly double direction;
+
+            private
+            Vector2(double p_x, double p_y, double p_magnitude, double p_direction)
+            {
+                x = p_x;
+                y = p_y;
+                magnitude = p_magnitude;
+                direction = p_direction;
+            }
+
+            public static Vector2
+            Polar(double magnitude, double direction)
+            {
+                magnitude = Math.Abs(magnitude);
+
+                const double twoPI = 2 * Math.PI;
+                for (; direction < 0D;) { direction += twoPI; }
+                for (; direction > twoPI;) { direction -= twoPI; }
+
+                double x = (magnitude * Math.Cos(direction));
+                double y = (magnitude * Math.Sin(direction));
+
+                return new Vector2(x, y, magnitude, direction);
+            }
+
+            public static Vector2
+            Cartesian(double x, double y)
+            {
+                double magnitude =
+                Math.Abs(Math.Sqrt(Math.Pow(x, 2) + Math.Pow(y, 2)));
+
+                double direction = Math.Atan2(y, x);
+                {
+                    const double twoPI = 2 * Math.PI;
+                    for (; direction < 0D;) { direction += twoPI; }
+                    for (; direction > twoPI;) { direction -= twoPI; }
+                }
+
+                return new Vector2(x, y, magnitude, direction);
+            }
+
+            public static Vector2 operator +
+            (Vector2 left, Vector2 right)
+            {
+                return Vector2.Cartesian
+                    (left.x + right.x, left.y + right.y);
+            }
+
+            public static Vector2 operator -
+            (Vector2 left, Vector2 right)
+            {
+                return Vector2.Cartesian
+                    (left.x + (-right.x), left.y + (-right.y));
+            }
+
+            public static Vector2
+            Reverse(Vector2 vector)
+            {
+                return Vector2.Cartesian
+                    (-(vector.x), -(vector.y));
+            }
+
+            public static Vector2
+            Scale(Vector2 vector, double scalar)
+            {
+                return Vector2.Polar
+                    (vector.magnitude * scalar, vector.direction);
+            }
+        }
+
+        public struct
+        Line2
+        {
+            public readonly double
+            slope,
+            xIntercept,
+            yIntercept;
+
+            public Line2(double p_slope, double p_xIntercept, double p_yIntercept)
+            {
+                slope = p_slope;
+                xIntercept = p_xIntercept;
+                yIntercept = p_yIntercept;
+            }
+
+            public static Line2
+            DefineByX(double xIntercept)
+            {
+                return new Line2(double.NaN, xIntercept, double.NaN);
+            }
+
+            public static Line2
+            DefineByY(double yIntercept)
+            {
+                return new Line2(0D, double.NaN, yIntercept);
+            }
+        }
+
+        public struct
+        LineSegment2
+        {
+            public readonly vec2
+            point1,
+            point2;
+
+            public readonly Line2
+            equation;
+
+            public
+            LineSegment2(vec2 p_point1, vec2 p_point2)
+            {
+                point1 = p_point1;
+                point2 = p_point2;
+
+                double dx = Math.Abs(point2.northing - point1.northing);
+                double dy = Math.Abs(point2.easting - point1.easting);
+
+                double
+                xIntercept,
+                yIntercept;
+
+                if (dx == 0D && dy == 0D)
+                {
+                    equation = new Line2(double.NaN, double.NaN, double.NaN);
+                    return;
+                }
+                if (dx == 0)
+                {
+                    xIntercept = (point1.northing + point2.northing) * 0.5;
+                    equation = Line2.DefineByX(xIntercept);
+                    return;
+                }
+                if (dy == 0D)
+                {
+                    yIntercept = (point1.easting + point2.easting) * 0.5;
+                    equation = Line2.DefineByY(yIntercept);
+                    return;
+                }
+
+                double slope =
+                    (point2.easting - point1.easting) /
+                    (point2.northing - point1.northing);
+
+                yIntercept =
+                point1.easting -
+                (slope * point1.northing);
+
+                xIntercept = (0D - yIntercept) / slope;
+
+                equation = new Line2(slope, xIntercept, yIntercept);
+            }
+
+            public double
+            Length()
+            {
+                return Math.Sqrt(
+                    Math.Pow(point2.northing - point1.northing, 2) +
+                    Math.Pow(point2.easting - point1.easting, 2));
+            }
+        }
+
+        public struct
+        Ray2
+        {
+            public readonly vec2 point;
+            public readonly double direction;
+            public readonly Line2 equation;
+
+            public
+            Ray2(vec2 p_point, double p_direction)
+            {
+                point = p_point;
+
+                direction = p_direction;
+                {
+                    const double twoPI = 2 * Math.PI;
+                    for (; direction < 0D;) { direction += twoPI; }
+                    for (; direction > twoPI;) { direction -= twoPI; }
+                }
+
+                if (direction == 0D || direction == Math.PI)
+                {
+                    equation = Line2.DefineByY(point.easting);
+                    return;
+                }
+                if (direction == (Math.PI * 0.5) ||
+                    direction == (Math.PI * 1.5))
+                {
+                    equation = Line2.DefineByX(point.northing);
+                    return;
+                }
+
+                double
+                slope = Math.Tan(direction),
+                yIntercept = point.easting - (slope * point.northing),
+                xIntercept = (0D - yIntercept) / slope;
+
+                equation = new Line2(slope, xIntercept, yIntercept);
+            }
+        }
+
+        private static int
+        CheckParallel(Line2 line)
+        {
+            if (line.slope != 0D && !double.IsNaN(line.slope)) return 0;
+            if (line.slope == 0D) return 1;
+            if (double.IsNaN(line.slope)) return 2;
+            return -1;
+        }
+
+        private static int
+        IntersectPoint
+        (Line2[] equation, out vec2 point)
+        {
+            int[] orientation = new int[2];
+            {
+                int[] check = new int[2]
+                {
+                    CheckParallel(equation[0]),
+                    CheckParallel(equation[1])
+                };
+
+                if (check[0] == -1 || check[1] == -1)
+                {
+                    point = new vec2(double.NaN, double.NaN);
+                    return -1;
+                }
+
+                if (check[0] <= check[1])
+                {
+                    orientation[0] = check[0];
+                    orientation[1] = check[1];
+                }
+                if (check[1] < check[0])
+                {
+                    orientation[0] = check[1];
+                    orientation[1] = check[0];
+                    equation = new Line2[] { equation[1], equation[0] };
+                }
+            }
+
+            if (orientation[0] != orientation[1])
+            {
+                if (orientation[0] == 0)
+                {
+                    if (orientation[1] == 1)
+                    {
+                        double y = equation[1].yIntercept;
+                        double x =
+                            (y - equation[0].yIntercept) / equation[0].slope;
+                        point = new vec2(y, x);
+                        return 1;
+                    }
+                    if (orientation[1] == 2)
+                    {
+                        double x = equation[1].xIntercept;
+                        double y =
+                            (equation[0].slope * x) + equation[0].yIntercept;
+                        point = new vec2(y, x);
+                        return 1;
+                    }
+                }
+                if (orientation[0] == 1)
+                {
+                    if (orientation[1] == 2)
+                    {
+                        double y = equation[0].yIntercept;
+                        double x = equation[1].xIntercept;
+                        point = new vec2(y, x);
+                        return 1;
+                    }
+                }
+            }
+
+            if (orientation[0] != 0 && orientation[1] != 0)
+            {
+                point = new vec2(double.NaN, double.NaN);
+                return 0;
+            }
+
+            if (equation[0].slope == equation[1].slope)
+            {
+                point = new vec2(double.NaN, double.NaN);
+                return 0;
+            }
+
+            {
+                double x =
+                    (equation[0].yIntercept - equation[1].yIntercept) /
+                    (equation[1].slope - equation[0].slope);
+                double y = (equation[0].slope * x) + equation[0].yIntercept;
+                point = new vec2(y, x);
+                return 1;
+            }
+        }
+
+        private static int
+        BetweenPoints(vec2 refPoint1, vec2 refPoint2, vec2 point)
+        {
+            /*
+             * Credit to Stack Overflow user AKN's answer to:
+             * https://stackoverflow.com/questions/42868214/
+             * that was the basis for the code below.
+             */
+
+            double
+            dxl = refPoint2.northing - refPoint1.northing,
+            dyl = refPoint2.easting - refPoint1.easting;
+
+            if (Math.Abs(dxl) >= Math.Abs(dyl))
+            {
+                if (dxl > 0)
+                {
+                    if (refPoint1.northing <= point.northing
+                        && point.northing <= refPoint2.northing) return 1;
+                    else return 0;
+                }
+                else
+                {
+                    if (refPoint2.northing <= point.northing
+                        && point.northing <= refPoint1.northing) return 1;
+                    else return 0;
+                }
+            }
+            else
+            {
+                if (dyl > 0)
+                {
+                    if (refPoint1.easting <= point.easting
+                        && point.easting <= refPoint2.easting) return 1;
+                    else return 0;
+                }
+                else
+                {
+                    if (refPoint2.easting <= point.easting
+                        && point.easting <= refPoint1.easting) return 1;
+                    else return 0;
+                }
+            }
+        }
+
+        public static int
+        Intersect(Ray2 ray, LineSegment2 line, out vec2 point)
+        {
+            Line2[] equations = new Line2[2] { ray.equation, line.equation };
+
+            int status;
+            if ((status = IntersectPoint
+                    (equations, out point)) == 1)
+            {
+                if ((status = BetweenPoints
+                        (line.point1, line.point2, point)) == 1)
+                {
+                    double direction = Math.Atan2
+                        (point.easting - ray.point.easting,
+                         point.northing - ray.point.northing);
+                    {
+                        const double twoPI = 2 * Math.PI;
+                        for (; direction < 0D;) { direction += twoPI; }
+                        for (; direction > twoPI;) { direction -= twoPI; }
+                    }
+
+                    if (Math.Abs(direction - ray.direction) < 1D) { }
+                    else
+                    {
+                        point = new vec2(double.NaN, double.NaN);
+                        status = 0;
+                    }
+                }
+            }
+
+            return status;
+        }
+    }
+}

--- a/SourceCode/GPS/Classes/Utility.cs
+++ b/SourceCode/GPS/Classes/Utility.cs
@@ -1,0 +1,56 @@
+﻿using System;
+
+namespace AgOpenGPS
+{
+    public static class
+    Utility
+    {
+        const double TAU = (2 * Math.PI);
+
+        public static double
+        CheckAngle(double angle)
+        {
+            for (; angle < 0D;) { angle += TAU; }
+
+            for (; angle > TAU;) { angle -= TAU; }
+
+            return angle;
+        }
+
+        public static double
+        RelativeAngle_L(double angle1, double angle2)
+        {
+            angle1 = CheckAngle(angle1);
+            angle2 = CheckAngle(angle2);
+
+            if (angle1 > angle2)
+            {
+                return (angle2 + TAU) - angle1;
+            }
+            else if (angle1 < angle2)
+            {
+                return angle2 - angle1;
+            }
+
+            return 0D;
+        }
+
+        public static double
+        RelativeAngle_R(double angle1, double angle2)
+        {
+            angle1 = CheckAngle(angle1);
+            angle2 = CheckAngle(angle2);
+
+            if (angle1 < angle2)
+            {
+                return -((angle1 + TAU) - angle2);
+            }
+            else if (angle1 > angle2)
+            {
+                return -(angle1 - angle2);
+            }
+
+            return 0D;
+        }
+    }
+}

--- a/SourceCode/GPS/Classes/vec3.cs
+++ b/SourceCode/GPS/Classes/vec3.cs
@@ -1,6 +1,7 @@
 ﻿//Please, if you use this, share the improvements
 
 using System;
+using static AgOpenGPS.Geometrics;
 
 namespace AgOpenGPS
 {
@@ -162,6 +163,12 @@ namespace AgOpenGPS
         public static vec2 operator +(vec2 lhs, vec2 rhs)
         {
             return new vec2(lhs.easting + rhs.easting, lhs.northing + rhs.northing);
+        }
+
+        public static vec2
+        Translate(vec2 vec, Vector2 vector)
+        {
+            return new vec2(vec.easting + vector.y, vec.northing + vector.x);
         }
     }
 


### PR DESCRIPTION
My attempt at reworking the functionality of u-turns.

This pull request only contains the code for generation, it is not enabled, nor can it be turned on through the interface. However there is a diff file is attached to this request that can be applied using "git apply" to (hard-code) enable dynamic turns.

Dynamic u-turns are capable of following the turn-line and driving around internal boundaries.

In addition to the new turn generation method, a collection of new types and methods are included that drastically streamline some of the common and repetitive calculations and operations.

[enable_dynamic_uturn.txt](https://github.com/farmerbriantee/AgOpenGPS/files/4671244/enable_dynamic_uturn.txt)

* Had to upload the diff as a "txt" file due to Github, but should still work