### PR TITLE
appended space to field folder name, throwing exception

### DIFF
--- a/SourceCode/GPS/Forms/FormFieldDir.cs
+++ b/SourceCode/GPS/Forms/FormFieldDir.cs
@@ -65,7 +65,7 @@ namespace AgOpenGPS
 
             //append date time to name
 
-            mf.currentFieldDirectory = tboxFieldName.Text.Trim() + " ";
+            mf.currentFieldDirectory = tboxFieldName.Text.Trim(); // + " ";
 
             //date
             if (cboxAddDate.Checked) mf.currentFieldDirectory += " " + DateTime.Now.ToString("MMM.dd", CultureInfo.InvariantCulture);


### PR DESCRIPTION
Minor thing, throwing an exception for an un-necessary trailing space

Directory.CreateDirectory drops it silently but then it fails on 

`using (StreamWriter writer = new StreamWriter(dirField + myFileName))`

which expects it to still be there