### PR TITLE
Replace UDP broadcast by unicast for localhost

### DIFF
--- a/SourceCode/AgIO/Source/Forms/UDP.designer.cs
+++ b/SourceCode/AgIO/Source/Forms/UDP.designer.cs
@@ -29,8 +29,8 @@ namespace AgIO
         public bool isUDPNetworkConnected;
 
         //2 endpoints for local and 2 udp
-        private IPEndPoint epAgOpen = new IPEndPoint(IPAddress.Parse("127.255.255.255"), 15555);
-        private IPEndPoint epAgVR = new IPEndPoint(IPAddress.Parse("127.255.255.255"), 16666);
+        private IPEndPoint epAgOpen = new IPEndPoint(IPAddress.Parse("127.0.0.1"), 15555);
+        private IPEndPoint epAgVR = new IPEndPoint(IPAddress.Parse("127.0.0.1"), 16666);
         public IPEndPoint epModule = new IPEndPoint(IPAddress.Parse(
                 Properties.Settings.Default.etIP_SubnetOne.ToString() + "." +
                 Properties.Settings.Default.etIP_SubnetTwo.ToString() + "." +


### PR DESCRIPTION
Generally it is not good idea to use broadcast on localhost, moreover it is not enabled on most Linuxes.

Without this patch, AOG does not work on Linux with Wine, neither with Mono.