### PR TITLE
Avoid changing culture with language

### DIFF
--- a/SourceCode/GPS/Program.cs
+++ b/SourceCode/GPS/Program.cs
@@ -40,7 +40,7 @@ namespace AgOpenGPS
 
             if (Mutex.WaitOne(TimeSpan.Zero, true))
             {
-                Thread.CurrentThread.CurrentCulture = new System.Globalization.CultureInfo(Properties.Settings.Default.setF_culture);
+                // Thread.CurrentThread.CurrentCulture = new System.Globalization.CultureInfo(Properties.Settings.Default.setF_culture);
                 Thread.CurrentThread.CurrentUICulture = new System.Globalization.CultureInfo(Properties.Settings.Default.setF_culture);
                 Application.EnableVisualStyles();
                 Application.SetCompatibleTextRenderingDefault(false);


### PR DESCRIPTION
I was wondering why my clock was using the AM/PM convention, and I eventually figured the thing was tied to the UI locale. 
And since this detail isn't mentioned anywhere (and it doesn't seem the most of user-friendliness) I supposed it wasn't desired. 
I also wanted to add a comment in the code, but I just didn't feel comfortable speaking in the plural. 