### PR TITLE
Handle corrupted user.config gracefully

### DIFF
--- a/SourceCode/GPS/Program.cs
+++ b/SourceCode/GPS/Program.cs
@@ -33,11 +33,21 @@ namespace AgOpenGPS
             }
             else
             {
-                Settings.Default.setF_culture = regKey.GetValue("Language").ToString();
-                Settings.Default.Save();
-                regKey.Close();
+                try
+                {
+                    Settings.Default.setF_culture = regKey.GetValue("Language").ToString();
+                }
+                catch (System.Configuration.ConfigurationErrorsException ex)
+                {
+                    // Corrupted XML! Delete the file, the user can just reload when this fails to appear. No need to worry them
+                    MessageBoxButtons btns = MessageBoxButtons.OK;
+                    System.Windows.Forms.MessageBox.Show("Error detected in config file - fixing it now, please close this and restart app", "Problem!", btns);
+                    string filename = ((ex.InnerException as System.Configuration.ConfigurationErrorsException)?.Filename) as string;
+                    System.IO.File.Delete(filename);
+                    Settings.Default.Reload();
+                    Application.Exit();
+                }
             }
-
             if (Mutex.WaitOne(TimeSpan.Zero, true))
             {
                 Thread.CurrentThread.CurrentCulture = new System.Globalization.CultureInfo(Properties.Settings.Default.setF_culture);


### PR DESCRIPTION
If user.config (in %APPDATA%) is corrupt, then AOG will refuse to start. This is an edge case, but has been observed in the wild. Code will trap the inability to parse the XML, delete the user.config and advise the user that a corruption has been caught, advising them to simply reload the application to resolve the issue.