### PR TITLE
Simplified trailer position and heading calculation to just a single line of code.

### DIFF
--- a/SourceCode/GPS/Forms/Position.designer.cs
+++ b/SourceCode/GPS/Forms/Position.designer.cs
@@ -1106,9 +1106,8 @@ namespace AgOpenGPS
                     //Torriem rules!!!!! Oh yes, this is all his. Thank-you
                     if (distanceCurrentStepFix != 0)
                     {
-                        double t = (tool.tankTrailingHitchLength) / distanceCurrentStepFix;
-                        tankPos.easting = hitchPos.easting + t * (hitchPos.easting - tankPos.easting);
-                        tankPos.northing = hitchPos.northing + t * (hitchPos.northing - tankPos.northing);
+                        //all we need is this heading calculation, and then the tankPos
+                        //can be calculated after the jackknife check.
                         tankPos.heading = Math.Atan2(hitchPos.easting - tankPos.easting, hitchPos.northing - tankPos.northing);
                         if (tankPos.heading < 0) tankPos.heading += glm.twoPI;
 
@@ -1141,9 +1140,8 @@ namespace AgOpenGPS
                 //Torriem rules!!!!! Oh yes, this is all his. Thank-you
                 if (distanceCurrentStepFix != 0)
                 {
-                    double t = (tool.trailingHitchLength) / distanceCurrentStepFix;
-                    toolPivotPos.easting = tankPos.easting + t * (tankPos.easting - toolPivotPos.easting);
-                    toolPivotPos.northing = tankPos.northing + t * (tankPos.northing - toolPivotPos.northing);
+                    //all we need is this heading calculation, and then the toolPivotPos
+                    //can be calculated after the jackknife check.
                     toolPivotPos.heading = Math.Atan2(tankPos.easting - toolPivotPos.easting, tankPos.northing - toolPivotPos.northing);
                     if (toolPivotPos.heading < 0) toolPivotPos.heading += glm.twoPI;
                 }


### PR DESCRIPTION
It's not only even shorter, it's more accurate now too.  I've now reduced my contribution to AOG to just 2 measly lines of code.  

I realized that since the code recalculates the position of the trailer on the position of the tractor hitch and the heading, all that we really needed to calculate to make it work was the trailer's heading.  The t calculations were all unnecessary since the Math.Cos and Math.Sin were doing the same job.   And the whole basis of the approximation is to take the heading from the old trailer position to the new tractor position, which approximates the turning of the hitch.  A few lines later AOG was already recalculating the trailer position based on that heading.