### PR TITLE
Fix AgIO startup crash on corrupt user.config in %APPDATA%

### DIFF
--- a/SourceCode/AgIO/Source/Program.cs
+++ b/SourceCode/AgIO/Source/Program.cs
@@ -1,5 +1,7 @@
-﻿using Microsoft.Win32;
+﻿using AgIO.Properties;
+using Microsoft.Win32;
 using System;
+using System.Diagnostics;
 using System.Threading;
 using System.Windows.Forms;
 
@@ -32,9 +34,22 @@ namespace AgIO
             }
             else
             {
-                Properties.Settings.Default.setF_culture = regKey.GetValue("Language").ToString();
-                Properties.Settings.Default.Save();
-                regKey.Close();
+                try
+                {
+                    Properties.Settings.Default.setF_culture = regKey.GetValue("Language").ToString();
+                    Properties.Settings.Default.Save();
+                    regKey.Close();
+                }
+                catch (System.Configuration.ConfigurationErrorsException ex)
+                {
+                    // Corrupted XML! Delete the file, the user can just reload when this fails to appear. No need to worry them
+                    MessageBoxButtons btns = MessageBoxButtons.OK;
+                    System.Windows.Forms.MessageBox.Show("Error detected in config file - fixing it now, please close this and restart app", "Problem!", btns);
+                    string filename = ((ex.InnerException as System.Configuration.ConfigurationErrorsException)?.Filename) as string;
+                    System.IO.File.Delete(filename);
+                    Settings.Default.Reload();
+                    Application.Exit();
+                }
             }
 
             if (Mutex.WaitOne(TimeSpan.Zero, true))


### PR DESCRIPTION
Noticed that if the user.config gets corrupt somehow, AgIO won't start. Similar happened to AgOpenGpS and the same fix works fine.