### PR TITLE
Update GUI.Designer.cs - fixed bug for UTurn mode after changing configuration

### DIFF
--- a/SourceCode/GPS/Forms/GUI.Designer.cs
+++ b/SourceCode/GPS/Forms/GUI.Designer.cs
@@ -448,6 +448,7 @@ namespace AgOpenGPS
 
             //OGL control
             isUTurnOn = Properties.Settings.Default.setFeatures.isUTurnOn;
+            btnYouSkipEnable.Image = Resources.YouSkipOff;
             isLateralOn = Properties.Settings.Default.setFeatures.isLateralOn;
             isNudgeOn = Properties.Settings.Default.setFeatures.isABLineOn;
 


### PR DESCRIPTION
fixed bug: 
precondition: UTurn is on, and UTurn mode was set to the alternative mode (colored icon for UTurn: YouSkipOn.png) then: going to the configuration menue and accept (green button). Settings are reloaded. UTurn is set to off (red icon on the right); icon for UTurn mode has still the alternative mode icon (YouSkipOn.png); but in AGO internaly UTurn mode is set to the normal mode. So the UTurn mode does not fit to the icon. When pressing the icon UTurn mode is vice versa.