### PR TITLE
Use built-in `SystemInformation.PowerStatus` for detecting if charging

### DIFF
--- a/SourceCode/GPS/Forms/GUI.Designer.cs
+++ b/SourceCode/GPS/Forms/GUI.Designer.cs
@@ -921,7 +921,7 @@ namespace AgOpenGPS
             lblHardwareMessage.BringToFront();
             isHardwareMessages = Properties.Settings.Default.setDisplay_isHardwareMessages;
 
-            if ((int) PowerState.GetPowerLineStatus() == 1)
+            if (SystemInformation.PowerStatus.PowerLineStatus == PowerLineStatus.Online)
             {
                 btnChargeStatus.BackColor = Color.YellowGreen;
             }


### PR DESCRIPTION
The built-in [`PowerLineStatus`](https://learn.microsoft.com/en-us/dotnet/api/system.windows.forms.powerstatus.powerlinestatus) from [`SystemInformation.PowerStatus`](https://learn.microsoft.com/en-us/dotnet/api/system.windows.forms.systeminformation.powerstatus) gives the same information as the previously used interop call to [`GetSystemPowerStatus()`](https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-getsystempowerstatus).