### PR TITLE
Use `Path.Combine` instead of string concatenation

### DIFF
--- a/SourceCode/AgIO/Source/Forms/Controls.Designer.cs
+++ b/SourceCode/AgIO/Source/Forms/Controls.Designer.cs
@@ -271,9 +271,7 @@ namespace AgIO
             if (processName.Length == 0)
             {
                 //Start application here
-                DirectoryInfo di = new DirectoryInfo(Application.StartupPath);
-                string strPath = di.ToString();
-                strPath += "\\ModSim.exe";
+                string strPath = Path.Combine(Application.StartupPath, "ModSim.exe");
 
                 try
                 {
@@ -421,9 +419,7 @@ namespace AgIO
             if (processName.Length == 0)
             {
                 //Start application here
-                DirectoryInfo di = new DirectoryInfo(Application.StartupPath);
-                string strPath = di.ToString();
-                strPath += "\\AgOpenGPS.exe";
+                string strPath = Path.Combine(Application.StartupPath, "AgOpenGPS.exe");
 
                 try
                 {
@@ -451,9 +447,7 @@ namespace AgIO
             if (processName.Length == 0)
             {
                 //Start application here
-                DirectoryInfo di = new DirectoryInfo(Application.StartupPath);
-                string strPath = di.ToString();
-                strPath += "\\GPS_Out.exe";
+                string strPath = Path.Combine(Application.StartupPath, "GPS_Out.exe");
 
                 try
                 {

--- a/SourceCode/AgIO/Source/Forms/FormLoop.cs
+++ b/SourceCode/AgIO/Source/Forms/FormLoop.cs
@@ -84,32 +84,34 @@ namespace AgIO
         //First run
         private void FormLoop_Load(object sender, EventArgs e)
         {
-            if (Settings.Default.setF_workingDirectory == "Default")
-                baseDirectory = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments) + "\\AgOpenGPS\\";
-            else baseDirectory = Settings.Default.setF_workingDirectory + "\\AgOpenGPS\\";
+            string workingDirectory = Settings.Default.setF_workingDirectory == "Default"
+                ? Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments)
+                : Settings.Default.setF_workingDirectory;
+
+            baseDirectory = Path.Combine(workingDirectory, "AgOpenGPS");
 
             //get the fields directory, if not exist, create
-            profileDirectory = baseDirectory + "AgIO\\";
-            string dir = Path.GetDirectoryName(profileDirectory);
-            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir)) { Directory.CreateDirectory(dir); }
+            profileDirectory = Path.Combine(baseDirectory, "AgIO");
+            DirectoryInfo profileDirectoryInfo = new DirectoryInfo(profileDirectory);
+            if (!profileDirectoryInfo.Exists)
+                profileDirectoryInfo.Create();
 
-            DirectoryInfo dinfo = new DirectoryInfo(profileDirectory);
-            FileInfo[] Files = dinfo.GetFiles("*.xml");
+            FileInfo[] profileFiles = profileDirectoryInfo.GetFiles("*.xml");
 
-            if (Files.Length == 0)
+            if (profileFiles.Length == 0)
             {
-                SettingsIO.ExportSettings(profileDirectory + "Default Profile.xml");
-            }
+                SettingsIO.ExportSettings(Path.Combine(profileDirectory, "Default Profile.xml"));
 
-            dinfo = new DirectoryInfo(profileDirectory);
-            FileInfo[] Filess = dinfo.GetFiles("*.xml");
+                //get list of files again, because it just changed by exporting the default profile
+                profileFiles = profileDirectoryInfo.GetFiles("*.xml");
+            }
 
             bool isDefault = false;
             bool isProfileExist = false;
 
             profileFileName = Settings.Default.setConfig_profileName;
 
-            foreach (FileInfo file in Filess)
+            foreach (FileInfo file in profileFiles)
             {
                 string temp = Path.GetFileNameWithoutExtension(file.Name).Trim();
                 if (temp == "Default Profile")
@@ -124,7 +126,7 @@ namespace AgIO
             }
 
             if (!isDefault)
-                SettingsIO.ExportSettings(profileDirectory + "Default Profile.xml");
+                SettingsIO.ExportSettings(Path.Combine(profileDirectory, "Default Profile.xml"));
 
             if (!isProfileExist)
             {
@@ -380,7 +382,7 @@ namespace AgIO
             Settings.Default.Save();
 
             //if (profileFileName != "Default Profile")
-                SettingsIO.ExportSettings(profileDirectory + profileFileName + ".xml");
+                SettingsIO.ExportSettings(Path.Combine(profileDirectory, profileFileName + ".xml"));
             //else
                 //YesMessageBox("Using Default Profile" + "\r\n\r\n" + "Changes will NOT be Saved");
 

--- a/SourceCode/GPS/Forms/Controls.Designer.cs
+++ b/SourceCode/GPS/Forms/Controls.Designer.cs
@@ -1130,9 +1130,8 @@ namespace AgOpenGPS
             if (processName.Length == 0)
             {
                 //Start application here
-                DirectoryInfo di = new DirectoryInfo(Application.StartupPath);
-                string strPath = di.ToString();
-                strPath += "\\AgIO.exe";
+                string strPath = Path.Combine(Application.StartupPath, "AgIO.exe");
+
                 try
                 {
                     //TimedMessageBox(2000, "Please Wait", "Starting AgIO");
@@ -1638,7 +1637,7 @@ namespace AgOpenGPS
             {
                 form.ShowDialog(this);
             }
-            SettingsIO.ExportAll(vehiclesDirectory + vehicleFileName + ".XML");
+            SettingsIO.ExportAll(Path.Combine(vehiclesDirectory, vehicleFileName + ".XML"));
         }
         private void colorsSectionToolStripMenuItem_Click(object sender, EventArgs e)
         {
@@ -1648,7 +1647,7 @@ namespace AgOpenGPS
                 {
                     form.ShowDialog(this);
                 }
-                SettingsIO.ExportAll(vehiclesDirectory + vehicleFileName + ".XML");
+                SettingsIO.ExportAll(Path.Combine(vehiclesDirectory, vehicleFileName + ".XML"));
             }
             else
             {
@@ -1870,7 +1869,7 @@ namespace AgOpenGPS
             FileSaveSystemEvents();
             sbSystemEvents.Clear();
 
-            FileInfo txtfile = new FileInfo(logsDirectory + "zSystemEventsLog_log.txt");
+            FileInfo txtfile = new FileInfo(Path.Combine(logsDirectory, "zSystemEventsLog_log.txt"));
             if (txtfile.Exists)
             {
                 Process.Start("notepad.exe", txtfile.FullName);
@@ -2334,9 +2333,8 @@ namespace AgOpenGPS
         }
         private void lblHz_Click(object sender, EventArgs e)
         {
-            DirectoryInfo di = new DirectoryInfo(Application.StartupPath);
-            string strPath = di.ToString();
-            strPath += "\\OGL.exe";
+            string strPath = Path.Combine(Application.StartupPath, "OGL.exe");
+
             try
             {
                 ProcessStartInfo processInfo = new ProcessStartInfo();
@@ -2391,7 +2389,7 @@ namespace AgOpenGPS
                 FileSaveSingleFlagKML(flagNumberPicked);
 
                 //Process.Start(@"C:\Program Files (x86)\Google\Google Earth\client\googleearth", workingDirectory + currentFieldDirectory + "\\Flags.KML");
-                Process.Start(fieldsDirectory + currentFieldDirectory + "\\Flag.KML");
+                Process.Start(Path.Combine(fieldsDirectory, currentFieldDirectory, "Flag.KML"));
             }
         }
 

--- a/SourceCode/GPS/Forms/Field/FormBoundary.cs
+++ b/SourceCode/GPS/Forms/Field/FormBoundary.cs
@@ -249,7 +249,7 @@ namespace AgOpenGPS
             //save new copy of kml with selected flag and view in GoogleEarth
 
             mf.FileMakeKMLFromCurrentPosition(mf.pn.latitude, mf.pn.longitude);
-            System.Diagnostics.Process.Start(mf.fieldsDirectory + mf.currentFieldDirectory + "\\CurrentPosition.KML");
+            System.Diagnostics.Process.Start(Path.Combine(mf.fieldsDirectory, mf.currentFieldDirectory, "CurrentPosition.KML"));
             isClosing = true;
             Close();
         }
@@ -319,7 +319,7 @@ namespace AgOpenGPS
                         Filter = "KML files (*.KML)|*.KML",
 
                         //the initial directory, fields, for the open dialog
-                        InitialDirectory = mf.fieldsDirectory + mf.currentFieldDirectory
+                        InitialDirectory = Path.Combine(mf.fieldsDirectory, mf.currentFieldDirectory)
                     };
 
                     //was a file selected

--- a/SourceCode/GPS/Forms/Field/FormFieldDir.cs
+++ b/SourceCode/GPS/Forms/Field/FormFieldDir.cs
@@ -81,7 +81,7 @@ namespace AgOpenGPS
             mf.currentFieldDirectory = tboxFieldName.Text.Trim();
 
             //get the directory and make sure it exists, create if not
-            string dirNewField = mf.fieldsDirectory + mf.currentFieldDirectory + "\\";
+            DirectoryInfo dirNewField = new DirectoryInfo(Path.Combine(mf.fieldsDirectory, mf.currentFieldDirectory));
 
             mf.menustripLanguage.Enabled = false;
             //if no template set just make a new file.
@@ -91,9 +91,7 @@ namespace AgOpenGPS
                 mf.JobNew();
 
                 //create it for first save
-                string directoryName = Path.GetDirectoryName(dirNewField);
-
-                if ((!string.IsNullOrEmpty(directoryName)) && (Directory.Exists(directoryName)))
+                if (dirNewField.Exists)
                 {
                     MessageBox.Show(gStr.gsChooseADifferentName, gStr.gsDirectoryExists, MessageBoxButtons.OK, MessageBoxIcon.Stop);
                     return;
@@ -104,9 +102,7 @@ namespace AgOpenGPS
 
                     mf.pn.SetLocalMetersPerDegree();
 
-                    //make sure directory exists, or create it
-                    if ((!string.IsNullOrEmpty(directoryName)) && (!Directory.Exists(directoryName)))
-                    { Directory.CreateDirectory(directoryName); }
+                    dirNewField.Create();
 
                     mf.displayFieldName = mf.currentFieldDirectory;
 

--- a/SourceCode/GPS/Forms/Field/FormFieldExisting.cs
+++ b/SourceCode/GPS/Forms/Field/FormFieldExisting.cs
@@ -55,7 +55,7 @@ namespace AgOpenGPS
                 double lonStart = 0;
                 double distance = 0;
                 string fieldDirectory = Path.GetFileName(dir);
-                string filename = dir + "\\Field.txt";
+                string filename = Path.Combine(dir, "Field.txt");
                 string line;
 
                 //make sure directory has a field.txt in it
@@ -109,7 +109,7 @@ namespace AgOpenGPS
                 else continue;
 
                 //grab the boundary area
-                filename = dir + "\\Boundary.txt";
+                filename = Path.Combine(dir, "Boundary.txt");
                 if (File.Exists(filename))
                 {
                     List<vec3> pointList = new List<vec3>();
@@ -194,7 +194,7 @@ namespace AgOpenGPS
                     MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
 
-                filename = dir + "\\Field.txt";
+                filename = Path.Combine(dir, "Field.txt");
             }
 
             if (fileList == null || fileList.Count < 1)
@@ -272,7 +272,7 @@ namespace AgOpenGPS
                 return;
             }
 
-            string fileStr = mf.fieldsDirectory + lblTemplateChosen.Text + "\\Field.txt";
+            string fileStr = Path.Combine(mf.fieldsDirectory, lblTemplateChosen.Text, "Field.txt");
 
             if (!File.Exists(fileStr))
             {
@@ -283,11 +283,9 @@ namespace AgOpenGPS
             if (mf.isJobStarted) mf.FileSaveEverythingBeforeClosingField();
 
             //get the directory and make sure it exists, create if not
-            string dirNewField = mf.fieldsDirectory + tboxFieldName.Text.Trim() + "\\";
+            string directoryName = Path.Combine(mf.fieldsDirectory, tboxFieldName.Text.Trim());
 
             // create from template
-            string directoryName = Path.GetDirectoryName(dirNewField);
-
             if (Directory.Exists(directoryName))
             {
                 MessageBox.Show(gStr.gsChooseADifferentName, gStr.gsDirectoryExists, MessageBoxButtons.OK, MessageBoxIcon.Stop);
@@ -332,7 +330,7 @@ namespace AgOpenGPS
 
                 const string myFileName = "Field.txt";
 
-                using (StreamWriter writer = new StreamWriter(dirNewField + myFileName))
+                using (StreamWriter writer = new StreamWriter(Path.Combine(directoryName, myFileName)))
                 {
                     //Write out the date
                     writer.WriteLine(DateTime.Now.ToString("yyyy-MMMM-dd hh:mm:ss tt", CultureInfo.InvariantCulture));
@@ -352,72 +350,72 @@ namespace AgOpenGPS
                 }
 
                 //create txt file copies
-                string templateDirectoryName = (mf.fieldsDirectory + lblTemplateChosen.Text);
+                string templateDirectoryName = Path.Combine(mf.fieldsDirectory, lblTemplateChosen.Text);
                 string fileToCopy = "";
                 string destinationDirectory = "";
 
                 if (chkApplied.Checked)
                 {
-                    fileToCopy = templateDirectoryName + "\\Contour.txt";
-                    destinationDirectory = directoryName + "\\Contour.txt";
+                    fileToCopy = Path.Combine(templateDirectoryName, "Contour.txt");
+                    destinationDirectory = Path.Combine(directoryName, "Contour.txt");
                     if (File.Exists(fileToCopy))
                         File.Copy(fileToCopy, destinationDirectory);
 
-                    fileToCopy = templateDirectoryName + "\\Sections.txt";
-                    destinationDirectory = directoryName + "\\Sections.txt";
+                    fileToCopy = Path.Combine(templateDirectoryName, "Sections.txt");
+                    destinationDirectory = Path.Combine(directoryName, "Sections.txt");
                     if (File.Exists(fileToCopy))
                         File.Copy(fileToCopy, destinationDirectory);
                 }
                 else
                 {
                     //create blank Contour and Section files
-                    using (StreamWriter writer = new StreamWriter(dirNewField + "\\Sections.txt"))
+                    using (StreamWriter writer = new StreamWriter(Path.Combine(directoryName, "Sections.txt")))
                     {
                         //blank
                     }
 
-                    using (StreamWriter writer = new StreamWriter(dirNewField + "\\Contour.txt"))
+                    using (StreamWriter writer = new StreamWriter(Path.Combine(directoryName, "Contour.txt")))
                     {
                         writer.WriteLine("$Contour");
                     }
                 }
 
-                fileToCopy = templateDirectoryName + "\\BackPic.txt";
-                destinationDirectory = directoryName + "\\BackPic.txt";
+                fileToCopy = Path.Combine(templateDirectoryName, "BackPic.txt");
+                destinationDirectory = Path.Combine(directoryName, "BackPic.txt");
                 if (File.Exists(fileToCopy))
                     File.Copy(fileToCopy, destinationDirectory);
 
-                fileToCopy = templateDirectoryName + "\\BackPic.png";
-                destinationDirectory = directoryName + "\\BackPic.png";
+                fileToCopy = Path.Combine(templateDirectoryName, "BackPic.png");
+                destinationDirectory = Path.Combine(directoryName, "BackPic.png");
                 if (File.Exists(fileToCopy))
                     File.Copy(fileToCopy, destinationDirectory);
 
-                fileToCopy = templateDirectoryName + "\\Boundary.txt";
-                destinationDirectory = directoryName + "\\Boundary.txt";
+                fileToCopy = Path.Combine(templateDirectoryName, "Boundary.txt");
+                destinationDirectory = Path.Combine(directoryName, "Boundary.txt");
                 if (File.Exists(fileToCopy))
                     File.Copy(fileToCopy, destinationDirectory);
 
 
-                fileToCopy = templateDirectoryName + "\\Headlines.txt";
-                destinationDirectory = directoryName + "\\Headlines.txt";
+                fileToCopy = Path.Combine(templateDirectoryName, "Headlines.txt");
+                destinationDirectory = Path.Combine(directoryName, "Headlines.txt");
                 if (File.Exists(fileToCopy))
                     File.Copy(fileToCopy, destinationDirectory);
                 else
-                    using (StreamWriter writer = new StreamWriter(dirNewField + "\\Headlines.txt"))
+                    using (StreamWriter writer = new StreamWriter(Path.Combine(directoryName, "Headlines.txt")))
                     {
                         writer.WriteLine("$Headlines");
                     }
 
                 if (chkFlags.Checked)
                 {
-                    fileToCopy = templateDirectoryName + "\\Flags.txt";
-                    destinationDirectory = directoryName + "\\Flags.txt";
+                    fileToCopy = Path.Combine(templateDirectoryName, "Flags.txt");
+                    destinationDirectory = Path.Combine(directoryName, "Flags.txt");
                     if (File.Exists(fileToCopy))
                         File.Copy(fileToCopy, destinationDirectory);
                 }
                 else
                 {
-                    using (StreamWriter writer = new StreamWriter(dirNewField + "\\Flags.txt"))
+                    using (StreamWriter writer = new StreamWriter(Path.Combine(directoryName, "Flags.txt")))
                     {
                         writer.WriteLine("$Flags");
                         writer.WriteLine("0");
@@ -426,29 +424,29 @@ namespace AgOpenGPS
 
                 if (chkGuidanceLines.Checked)
                 {
-                    fileToCopy = templateDirectoryName + "\\ABLines.txt";
-                    destinationDirectory = directoryName + "\\ABLines.txt";
+                    fileToCopy = Path.Combine(templateDirectoryName, "ABLines.txt");
+                    destinationDirectory = Path.Combine(directoryName, "ABLines.txt");
                     if (File.Exists(fileToCopy))
                         File.Copy(fileToCopy, destinationDirectory);
 
-                    fileToCopy = templateDirectoryName + "\\RecPath.txt";
-                    destinationDirectory = directoryName + "\\RecPath.txt";
+                    fileToCopy = Path.Combine(templateDirectoryName, "RecPath.txt");
+                    destinationDirectory = Path.Combine(directoryName, "RecPath.txt");
                     if (File.Exists(fileToCopy))
                         File.Copy(fileToCopy, destinationDirectory);
 
-                    fileToCopy = templateDirectoryName + "\\CurveLines.txt";
-                    destinationDirectory = directoryName + "\\CurveLines.txt";
+                    fileToCopy = Path.Combine(templateDirectoryName, "CurveLines.txt");
+                    destinationDirectory = Path.Combine(directoryName, "CurveLines.txt");
                     if (File.Exists(fileToCopy))
                         File.Copy(fileToCopy, destinationDirectory);
 
-                    fileToCopy = templateDirectoryName + "\\Tram.txt";
-                    destinationDirectory = directoryName + "\\Tram.txt";
+                    fileToCopy = Path.Combine(templateDirectoryName, "Tram.txt");
+                    destinationDirectory = Path.Combine(directoryName, "Tram.txt");
                     if (File.Exists(fileToCopy))
                         File.Copy(fileToCopy, destinationDirectory);
                 }
                 else
                 {
-                    using (StreamWriter writer = new StreamWriter(dirNewField + "\\RecPath.txt"))
+                    using (StreamWriter writer = new StreamWriter(Path.Combine(directoryName, "RecPath.txt")))
                     {
                         writer.WriteLine("$RecPath");
                         writer.WriteLine("0");
@@ -457,14 +455,14 @@ namespace AgOpenGPS
 
                 if (chkHeadland.Checked)
                 {
-                    fileToCopy = templateDirectoryName + "\\Headland.txt";
-                    destinationDirectory = directoryName + "\\Headland.txt";
+                    fileToCopy = Path.Combine(templateDirectoryName, "Headland.txt");
+                    destinationDirectory = Path.Combine(directoryName, "Headland.txt");
                     if (File.Exists(fileToCopy))
                         File.Copy(fileToCopy, destinationDirectory);
                 }
 
                 //now open the newly cloned field
-                mf.FileOpenField(dirNewField + myFileName);
+                mf.FileOpenField(Path.Combine(directoryName, myFileName));
                 mf.displayFieldName = mf.currentFieldDirectory;
             }
 

--- a/SourceCode/GPS/Forms/Field/FormFieldISOXML.cs
+++ b/SourceCode/GPS/Forms/Field/FormFieldISOXML.cs
@@ -206,11 +206,9 @@ namespace AgOpenGPS
         private void btnBuildFields_Click(object sender, EventArgs e)
         {
             mf.currentFieldDirectory = tboxFieldName.Text.Trim();
-            string dirNewField = mf.fieldsDirectory + mf.currentFieldDirectory + "\\";
+            string directoryName = Path.Combine(mf.fieldsDirectory, mf.currentFieldDirectory);
 
             //create new field files.
-            string directoryName = Path.GetDirectoryName(dirNewField);
-
             if ((!string.IsNullOrEmpty(directoryName)) && (Directory.Exists(directoryName)))
             {
                 MessageBox.Show(gStr.gsChooseADifferentName, gStr.gsDirectoryExists, MessageBoxButtons.OK, MessageBoxIcon.Stop);
@@ -320,18 +318,17 @@ namespace AgOpenGPS
                         mf.TimedMessageBox(3000, gStr.gsFieldNotOpen, gStr.gsCreateNewField);
                         return;
                     }
-                    string myFileName, dirField;
+                    string myFileName;
 
                     //get the directory and make sure it exists, create if not
-                    dirField = mf.fieldsDirectory + mf.currentFieldDirectory + "\\";
-                    directoryName = Path.GetDirectoryName(dirField);
+                    directoryName = Path.Combine(mf.fieldsDirectory, mf.currentFieldDirectory);
 
                     if ((directoryName.Length > 0) && (!Directory.Exists(directoryName)))
                     { Directory.CreateDirectory(directoryName); }
 
                     myFileName = "Field.txt";
 
-                    using (StreamWriter writer = new StreamWriter(dirField + myFileName))
+                    using (StreamWriter writer = new StreamWriter(Path.Combine(directoryName, myFileName)))
                     {
                         //Write out the date
                         writer.WriteLine(DateTime.Now.ToString("yyyy-MMMM-dd hh:mm:ss tt", CultureInfo.InvariantCulture));

--- a/SourceCode/GPS/Forms/Field/FormFieldKML.cs
+++ b/SourceCode/GPS/Forms/Field/FormFieldKML.cs
@@ -311,7 +311,7 @@ namespace AgOpenGPS
             mf.currentFieldDirectory = tboxFieldName.Text.Trim();
 
             //get the directory and make sure it exists, create if not
-            string dirNewField = mf.fieldsDirectory + mf.currentFieldDirectory + "\\";
+            string directoryName = Path.Combine(mf.fieldsDirectory, mf.currentFieldDirectory);
 
             mf.menustripLanguage.Enabled = false;
             //if no template set just make a new file.
@@ -321,8 +321,6 @@ namespace AgOpenGPS
                 mf.JobNew();
 
                 //create it for first save
-                string directoryName = Path.GetDirectoryName(dirNewField);
-
                 if ((!string.IsNullOrEmpty(directoryName)) && (Directory.Exists(directoryName)))
                 {
                     MessageBox.Show(gStr.gsChooseADifferentName, gStr.gsDirectoryExists, MessageBoxButtons.OK, MessageBoxIcon.Stop);
@@ -358,18 +356,17 @@ namespace AgOpenGPS
                         mf.TimedMessageBox(3000, gStr.gsFieldNotOpen, gStr.gsCreateNewField);
                         return;
                     }
-                    string myFileName, dirField;
+                    string myFileName;
 
                     //get the directory and make sure it exists, create if not
-                    dirField = mf.fieldsDirectory + mf.currentFieldDirectory + "\\";
-                    directoryName = Path.GetDirectoryName(dirField);
+                    directoryName = Path.Combine(mf.fieldsDirectory, mf.currentFieldDirectory);
 
                     if ((directoryName.Length > 0) && (!Directory.Exists(directoryName)))
                     { Directory.CreateDirectory(directoryName); }
 
                     myFileName = "Field.txt";
 
-                    using (StreamWriter writer = new StreamWriter(dirField + myFileName))
+                    using (StreamWriter writer = new StreamWriter(Path.Combine(directoryName, myFileName)))
                     {
                         //Write out the date
                         writer.WriteLine(DateTime.Now.ToString("yyyy-MMMM-dd hh:mm:ss tt", CultureInfo.InvariantCulture));

--- a/SourceCode/GPS/Forms/Field/FormJob.cs
+++ b/SourceCode/GPS/Forms/Field/FormJob.cs
@@ -34,9 +34,9 @@ namespace AgOpenGPS
         {
             //check if directory and file exists, maybe was deleted etc
             if (String.IsNullOrEmpty(mf.currentFieldDirectory)) btnJobResume.Enabled = false;
-            string directoryName = mf.fieldsDirectory + mf.currentFieldDirectory + "\\";
+            string directoryName = Path.Combine(mf.fieldsDirectory, mf.currentFieldDirectory);
 
-            string fileAndDirectory = directoryName + "Field.txt";
+            string fileAndDirectory = Path.Combine(directoryName, "Field.txt");
 
             if (!File.Exists(fileAndDirectory))
             {
@@ -131,7 +131,7 @@ namespace AgOpenGPS
                 double lon = 0;
 
                 string fieldDirectory = Path.GetFileName(dir);
-                string filename = dir + "\\Field.txt";
+                string filename = Path.Combine(dir, "Field.txt");
                 string line;
 
                 //make sure directory has a field.txt in it
@@ -199,7 +199,7 @@ namespace AgOpenGPS
                 }
                 else // 1 field found
                 {
-                    mf.filePickerFileAndDirectory = mf.fieldsDirectory + infieldList + "\\Field.txt";
+                    mf.filePickerFileAndDirectory = Path.Combine(mf.fieldsDirectory, infieldList, "Field.txt");
                     mf.FileOpenField(mf.filePickerFileAndDirectory);
                     Close();
                 }

--- a/SourceCode/GPS/Forms/FormGPS.cs
+++ b/SourceCode/GPS/Forms/FormGPS.cs
@@ -411,40 +411,38 @@ namespace AgOpenGPS
 
             string[] fullVers = currentVersionStr.Split('.');
 
-            if (Settings.Default.setF_workingDirectory == "Default")
-                baseDirectory = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments) + "\\AgOpenGPS\\";
-            else baseDirectory = Settings.Default.setF_workingDirectory + "\\AgOpenGPS\\";
+            string workingDirectory = Settings.Default.setF_workingDirectory == "Default"
+                ? Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments)
+                : Settings.Default.setF_workingDirectory;
+
+            baseDirectory = Path.Combine(workingDirectory, "AgOpenGPS");
 
             //get the fields directory, if not exist, create
-            fieldsDirectory = baseDirectory + "Fields\\";
-            string dir = Path.GetDirectoryName(fieldsDirectory);
-            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir)) { Directory.CreateDirectory(dir);
+            fieldsDirectory = Path.Combine(baseDirectory, "Fields");
+            if (!string.IsNullOrEmpty(fieldsDirectory) && !Directory.Exists(fieldsDirectory)) { Directory.CreateDirectory(fieldsDirectory);
                 sbSystemEvents.Append("Fields Dir Created\r");
             }
 
             //get the fields directory, if not exist, create
-            vehiclesDirectory = baseDirectory + "Vehicles\\";
-            dir = Path.GetDirectoryName(vehiclesDirectory);
-            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir)) { Directory.CreateDirectory(dir);
+            vehiclesDirectory = Path.Combine(baseDirectory, "Vehicles");
+            if (!string.IsNullOrEmpty(vehiclesDirectory) && !Directory.Exists(vehiclesDirectory)) { Directory.CreateDirectory(vehiclesDirectory);
                 sbSystemEvents.Append("Vehicles Dir Created\r");
             }
 
             //get the fields directory, if not exist, create
-            logsDirectory = baseDirectory + "Logs\\";
-            dir = Path.GetDirectoryName(logsDirectory);
-            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir)) { Directory.CreateDirectory(dir);
+            logsDirectory = Path.Combine(baseDirectory, "Logs");
+            if (!string.IsNullOrEmpty(logsDirectory) && !Directory.Exists(logsDirectory)) { Directory.CreateDirectory(logsDirectory);
                 sbSystemEvents.Append("Logs Dir Created\r");
             }
 
             //get the abLines directory, if not exist, create
-            ablinesDirectory = baseDirectory + "ABLines\\";
-            dir = Path.GetDirectoryName(fieldsDirectory);
-            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir)) { Directory.CreateDirectory(dir);
+            ablinesDirectory = Path.Combine(baseDirectory, "ABLines");
+            if (!string.IsNullOrEmpty(ablinesDirectory) && !Directory.Exists(ablinesDirectory)) { Directory.CreateDirectory(ablinesDirectory);
                 sbSystemEvents.Append("ABLines Dir Created\r");
             }
 
             //system event log file
-            FileInfo txtfile = new FileInfo(logsDirectory + "zSystemEventsLog_log.txt");
+            FileInfo txtfile = new FileInfo(Path.Combine(logsDirectory, "zSystemEventsLog_log.txt"));
             if (txtfile.Exists)
             {
                 if (txtfile.Length > (500000))       // ## NOTE: 0.5MB max file size
@@ -456,7 +454,7 @@ namespace AgOpenGPS
                     //create some extra space
                     lines /= 30;
 
-                    using (StreamReader reader = new StreamReader(logsDirectory + "zSystemEventsLog_log.txt"))
+                    using (StreamReader reader = new StreamReader(Path.Combine(logsDirectory, "zSystemEventsLog_log.txt")))
                     {
                         try
                         {
@@ -474,7 +472,7 @@ namespace AgOpenGPS
                         catch { }
                     }
 
-                    using (StreamWriter writer = new StreamWriter(logsDirectory + "zSystemEventsLog_log.txt"))
+                    using (StreamWriter writer = new StreamWriter(Path.Combine(logsDirectory, "zSystemEventsLog_log.txt")))
                     {
                         writer.WriteLine(sbF);
                     }
@@ -488,11 +486,9 @@ namespace AgOpenGPS
             //make sure current field directory exists, null if not
             currentFieldDirectory = Settings.Default.setF_CurrentDir;
 
-            string curDir;
             if (currentFieldDirectory != "")
             {
-                curDir = fieldsDirectory + currentFieldDirectory + "//";
-                dir = Path.GetDirectoryName(curDir);
+                string dir = Path.Combine(fieldsDirectory, currentFieldDirectory);
                 if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
                 {
                     currentFieldDirectory = "";
@@ -502,24 +498,24 @@ namespace AgOpenGPS
                 }
             }
 
-            DirectoryInfo dinfo = new DirectoryInfo(vehiclesDirectory + vehicleFileName);
-            FileInfo[] Files = dinfo.GetFiles("*.xml");
+            DirectoryInfo dinfo = new DirectoryInfo(Path.Combine(vehiclesDirectory, vehicleFileName));
+            FileInfo[] vehicleFiles = dinfo.GetFiles("*.xml");
 
-            if (Files.Length == 0)
+            if (vehicleFiles.Length == 0)
             {
-                SettingsIO.ExportAll(vehiclesDirectory + vehicleFileName + "Default Vehicle.xml");
+                SettingsIO.ExportAll(Path.Combine(vehiclesDirectory, vehicleFileName, "Default Vehicle.xml"));
                 sbSystemEvents.Append("Empty Vehicles Dir, Default Vehicle.xml Created\r");
-            }
 
-            dinfo = new DirectoryInfo(vehiclesDirectory + vehicleFileName);
-            FileInfo[] Filess = dinfo.GetFiles("*.xml");
+                //get list of files again, because it just changed by exporting the default vehicle
+                vehicleFiles = dinfo.GetFiles("*.xml");
+            }
 
             bool isDefault = false;
             bool isVehicleExist = false;
 
             vehicleFileName = Settings.Default.setVehicle_vehicleName;
 
-            foreach (FileInfo file in Filess)
+            foreach (FileInfo file in vehicleFiles)
             {
                 string temp = Path.GetFileNameWithoutExtension(file.Name).Trim();
                 if (temp == "Default Vehicle")
@@ -535,7 +531,7 @@ namespace AgOpenGPS
 
             if (!isDefault)
             {
-                SettingsIO.ExportAll(vehiclesDirectory + vehicleFileName + "Default Vehicle.xml");
+                SettingsIO.ExportAll(Path.Combine(vehiclesDirectory, vehicleFileName, "Default Vehicle.xml"));
                 sbSystemEvents.Append("Missing Default Vehicle.xml, Created\r");
             }
 
@@ -597,9 +593,7 @@ namespace AgOpenGPS
                 if (processName.Length == 0)
                 {
                     //Start application here
-                    DirectoryInfo di = new DirectoryInfo(Application.StartupPath);
-                    string strPath = di.ToString();
-                    strPath += "\\AgIO.exe";
+                    string strPath = Path.Combine(Application.StartupPath, "AgIO.exe");
                     try
                     {
                         ProcessStartInfo processInfo = new ProcessStartInfo
@@ -752,7 +746,7 @@ namespace AgOpenGPS
             FileSaveSystemEvents();
 
             //save current vehicle
-            SettingsIO.ExportAll(vehiclesDirectory + vehicleFileName + ".XML");
+            SettingsIO.ExportAll(Path.Combine(vehiclesDirectory, vehicleFileName + ".XML"));
 
             if (displayBrightness.isWmiMonitor)
                 displayBrightness.SetBrightness(Settings.Default.setDisplay_brightnessSystem);
@@ -1350,7 +1344,7 @@ namespace AgOpenGPS
                 //string strPath = Application.StartupPath;
 
                 //Write out the error appending to existing
-                File.AppendAllText(baseDirectory + "\\" + strFileName, strErrorText + " - " +
+                File.AppendAllText(Path.Combine(baseDirectory, strFileName), strErrorText + " - " +
                     DateTime.Now.ToString() + "\r\n\r\n");
             }
             catch (Exception ex)

--- a/SourceCode/GPS/Forms/FormMap.cs
+++ b/SourceCode/GPS/Forms/FormMap.cs
@@ -371,7 +371,7 @@ namespace AgOpenGPS
                 GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, 9729);
             }
 
-            String fileAndDirectory = mf.fieldsDirectory + mf.currentFieldDirectory + "\\BackPic.png";
+            string fileAndDirectory = Path.Combine(mf.fieldsDirectory, mf.currentFieldDirectory, "BackPic.png");
             try
             {
                 if (File.Exists(fileAndDirectory))
@@ -457,7 +457,7 @@ namespace AgOpenGPS
                 bitmap = glm.MakeGrayscale3(bitmap);
             }
 
-            String fileAndDirectory = mf.fieldsDirectory + mf.currentFieldDirectory + "\\BackPic.png";
+            string fileAndDirectory = Path.Combine(mf.fieldsDirectory, mf.currentFieldDirectory, "BackPic.png");
             try
             {
                 if (File.Exists(fileAndDirectory))

--- a/SourceCode/GPS/Forms/Guidance/FormBuildTracks.cs
+++ b/SourceCode/GPS/Forms/Guidance/FormBuildTracks.cs
@@ -980,7 +980,7 @@ namespace AgOpenGPS
                     Filter = "KML files (*.KML)|*.KML",
 
                     //the initial directory, fields, for the open dialog
-                    InitialDirectory = mf.fieldsDirectory + mf.currentFieldDirectory
+                    InitialDirectory = Path.Combine(mf.fieldsDirectory, mf.currentFieldDirectory)
                 };
 
                 //was a file selected

--- a/SourceCode/GPS/Forms/Pickers/FormDrivePicker.cs
+++ b/SourceCode/GPS/Forms/Pickers/FormDrivePicker.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Windows.Forms;
 
 namespace AgOpenGPS
@@ -33,7 +34,7 @@ namespace AgOpenGPS
             int count = lvLines.SelectedItems.Count;
             if (count > 0)
             {
-                mf.filePickerFileAndDirectory = (mf.fieldsDirectory + lvLines.SelectedItems[0].SubItems[0].Text + "\\Field.txt");
+                mf.filePickerFileAndDirectory = Path.Combine(mf.fieldsDirectory, lvLines.SelectedItems[0].SubItems[0].Text, "Field.txt");
                 Close();
             }
         }

--- a/SourceCode/GPS/Forms/Pickers/FormFilePicker.cs
+++ b/SourceCode/GPS/Forms/Pickers/FormFilePicker.cs
@@ -49,7 +49,7 @@ namespace AgOpenGPS
                 double lonStart = 0;
                 double distance = 0;
                 string fieldDirectory = Path.GetFileName(dir);
-                string filename = dir + "\\Field.txt";
+                string filename = Path.Combine(dir, "Field.txt");
                 string line;
 
                 //make sure directory has a field.txt in it
@@ -103,7 +103,7 @@ namespace AgOpenGPS
                 else continue;
 
                 //grab the boundary area
-                filename = dir + "\\Boundary.txt";
+                filename = Path.Combine(dir, "Boundary.txt");
                 if (File.Exists(filename))
                 {
                     List<vec3> pointList = new List<vec3>();
@@ -188,7 +188,7 @@ namespace AgOpenGPS
                     MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
 
-                filename = dir + "\\Field.txt";
+                filename = Path.Combine(dir, "Field.txt");
             }
 
             if (fileList == null || fileList.Count < 1)
@@ -309,9 +309,9 @@ namespace AgOpenGPS
                 else
                 {
                     if (order == 0) mf.filePickerFileAndDirectory =
-                            (mf.fieldsDirectory + lvLines.SelectedItems[0].SubItems[0].Text + "\\Field.txt");
+                            Path.Combine(mf.fieldsDirectory, lvLines.SelectedItems[0].SubItems[0].Text, "Field.txt");
                     else mf.filePickerFileAndDirectory =
-                            (mf.fieldsDirectory + lvLines.SelectedItems[0].SubItems[1].Text + "\\Field.txt");
+                            Path.Combine(mf.fieldsDirectory, lvLines.SelectedItems[0].SubItems[1].Text, "Field.txt");
                     Close();
                 }
             }
@@ -328,8 +328,10 @@ namespace AgOpenGPS
             string dir2Delete;
             if (count > 0)
             {
-                if (order == 0) dir2Delete = (mf.fieldsDirectory + lvLines.SelectedItems[0].SubItems[0].Text);
-                else dir2Delete = (mf.fieldsDirectory + lvLines.SelectedItems[0].SubItems[1].Text);
+                if (order == 0)
+                    dir2Delete = Path.Combine(mf.fieldsDirectory, lvLines.SelectedItems[0].SubItems[0].Text);
+                else
+                    dir2Delete = Path.Combine(mf.fieldsDirectory, lvLines.SelectedItems[0].SubItems[1].Text);
 
                 DialogResult result3 = MessageBox.Show(
                     dir2Delete,
@@ -357,7 +359,7 @@ namespace AgOpenGPS
                 double lonStart = 0;
                 double distance = 0;
                 string fieldDirectory = Path.GetFileName(dir);
-                string filename = dir + "\\Field.txt";
+                string filename = Path.Combine(dir, "Field.txt");
                 string line;
 
                 //make sure directory has a field.txt in it
@@ -409,7 +411,7 @@ namespace AgOpenGPS
                     }
 
                     //grab the boundary area
-                    filename = dir + "\\Boundary.txt";
+                    filename = Path.Combine(dir, "Boundary.txt");
                     if (File.Exists(filename))
                     {
                         List<vec3> pointList = new List<vec3>();

--- a/SourceCode/GPS/Forms/Pickers/FormRecordPicker.cs
+++ b/SourceCode/GPS/Forms/Pickers/FormRecordPicker.cs
@@ -30,7 +30,7 @@ namespace AgOpenGPS.Forms.Pickers
         {
             ListViewItem itm;
 
-            string fieldDir = mf.fieldsDirectory + mf.currentFieldDirectory;
+            string fieldDir = Path.Combine(mf.fieldsDirectory, mf.currentFieldDirectory);
 
             string[] files = Directory.GetFiles(fieldDir);
 
@@ -44,7 +44,7 @@ namespace AgOpenGPS.Forms.Pickers
             {
                 if (file.EndsWith(".rec"))
                 {
-                    string recordName = file.Replace(".rec", "").Replace(fieldDir, "").Replace("\\", "");
+                    string recordName = Path.GetFileNameWithoutExtension(file);
                     itm = new ListViewItem(recordName);
                     lvLines.Items.Add(itm);
                 }
@@ -64,11 +64,11 @@ namespace AgOpenGPS.Forms.Pickers
             if (count > 0)
             {
                 string selectedRecord = lvLines.SelectedItems[0].SubItems[0].Text;
-                string selectedRecordPath = mf.fieldsDirectory + mf.currentFieldDirectory + "\\" + selectedRecord + ".rec";
+                string selectedRecordPath = Path.Combine(mf.fieldsDirectory, mf.currentFieldDirectory, selectedRecord + ".rec");
 
                 // Copy the selected record file to the original record name inside the field dir:
                 // ( this will load the last selected path automatically when this field is opened again)
-                File.Copy(selectedRecordPath, mf.fieldsDirectory + mf.currentFieldDirectory + "\\RecPath.txt", true);
+                File.Copy(selectedRecordPath, Path.Combine(mf.fieldsDirectory, mf.currentFieldDirectory, "RecPath.txt"), true);
                 // and load the selected path into the recPath object:
                 string line;
                 if (File.Exists(selectedRecordPath))
@@ -118,7 +118,7 @@ namespace AgOpenGPS.Forms.Pickers
             if (count > 0)
             {
                 string selectedRecord = lvLines.SelectedItems[0].SubItems[0].Text;
-                dir2Delete = mf.fieldsDirectory + mf.currentFieldDirectory + "\\" + selectedRecord + ".rec";
+                dir2Delete = Path.Combine(mf.fieldsDirectory, mf.currentFieldDirectory, selectedRecord + ".rec");
 
                 DialogResult result3 = MessageBox.Show(
                     dir2Delete,

--- a/SourceCode/GPS/Forms/SaveOpen.Designer.cs
+++ b/SourceCode/GPS/Forms/SaveOpen.Designer.cs
@@ -27,9 +27,8 @@ namespace AgOpenGPS
             //if (bnd.bndList.Count < 1) return;//If no Bnd, Quit
 
             //get the directory and make sure it exists, create if not
-            string dirField = fieldsDirectory + currentFieldDirectory + "\\zISOXML\\v3\\";
+            string directoryName = Path.Combine(fieldsDirectory, currentFieldDirectory, "zISOXML", "v3");
 
-            string directoryName = Path.GetDirectoryName(dirField);
             if ((directoryName.Length > 0) && (!Directory.Exists(directoryName)))
             { Directory.CreateDirectory(directoryName); }
 
@@ -40,7 +39,7 @@ namespace AgOpenGPS
                 XmlWriterSettings settings = new XmlWriterSettings();
                 settings.Indent = true;
                 settings.IndentChars = "  ";
-                XmlWriter xml = XmlWriter.Create(dirField + myFileName, settings);
+                XmlWriter xml = XmlWriter.Create(Path.Combine(directoryName, myFileName), settings);
 
                 xml.WriteStartElement("ISO11783_TaskData");//Settings
                 xml.WriteAttributeString("DataTransferOrigin", "1");
@@ -222,9 +221,8 @@ namespace AgOpenGPS
             int lineCounter = 0;
 
             //get the directory and make sure it exists, create if not
-            string dirField = fieldsDirectory + currentFieldDirectory + "\\zISOXML\\v4\\";
+            string directoryName = Path.Combine(fieldsDirectory, currentFieldDirectory, "zISOXML", "v4");
 
-            string directoryName = Path.GetDirectoryName(dirField);
             if ((directoryName.Length > 0) && (!Directory.Exists(directoryName)))
             { Directory.CreateDirectory(directoryName); }
            
@@ -235,7 +233,7 @@ namespace AgOpenGPS
                 XmlWriterSettings settings = new XmlWriterSettings();
                 settings.Indent = true;
                 settings.IndentChars = "  ";
-                XmlWriter xml = XmlWriter.Create(dirField + myFileName, settings);
+                XmlWriter xml = XmlWriter.Create(Path.Combine(directoryName, myFileName), settings);
 
                 xml.WriteStartElement("ISO11783_TaskData");//Settings
                 xml.WriteAttributeString("DataTransferOrigin", "1");
@@ -470,13 +468,12 @@ namespace AgOpenGPS
 
         public void FileSaveHeadLines()
         {
-            string dirField = fieldsDirectory + currentFieldDirectory + "\\";
-            string directoryName = Path.GetDirectoryName(dirField).ToString(CultureInfo.InvariantCulture);
+            string directoryName = Path.Combine(fieldsDirectory, currentFieldDirectory);
 
-            if ((directoryName.Length > 0) && (!Directory.Exists(directoryName)))
+            if (!string.IsNullOrEmpty(directoryName) && (!Directory.Exists(directoryName)))
             { Directory.CreateDirectory(directoryName); }
 
-            string filename = directoryName + "\\Headlines.txt";
+            string filename = Path.Combine(directoryName, "Headlines.txt");
 
             int cnt = hdl.tracksArr.Count;
 
@@ -536,13 +533,12 @@ namespace AgOpenGPS
             hdl.tracksArr?.Clear();
 
             //get the directory and make sure it exists, create if not
-            string dirField = fieldsDirectory + currentFieldDirectory + "\\";
-            string directoryName = Path.GetDirectoryName(dirField);
+            string directoryName = Path.Combine(fieldsDirectory, currentFieldDirectory);
 
             if ((directoryName.Length > 0) && (!Directory.Exists(directoryName)))
             { Directory.CreateDirectory(directoryName); }
 
-            string filename = directoryName + "\\Headlines.txt";
+            string filename = Path.Combine(directoryName, "Headlines.txt");
 
             if (!File.Exists(filename))
             {
@@ -623,13 +619,12 @@ namespace AgOpenGPS
 
                         TimedMessageBox(2000, "Headline Error", "Lines Deleted");
 
-                        dirField = fieldsDirectory + currentFieldDirectory + "\\";
-                        directoryName = Path.GetDirectoryName(dirField).ToString(CultureInfo.InvariantCulture);
+                        directoryName = Path.Combine(fieldsDirectory, currentFieldDirectory);
 
-                        if ((directoryName.Length > 0) && (!Directory.Exists(directoryName)))
+                        if (!string.IsNullOrEmpty(directoryName) && (!Directory.Exists(directoryName)))
                         { Directory.CreateDirectory(directoryName); }
 
-                        filename = directoryName + "\\Headlines.txt";
+                        filename = Path.Combine(directoryName, "Headlines.txt");
 
                         using (StreamWriter writer = new StreamWriter(filename, false))
                         {
@@ -651,13 +646,12 @@ namespace AgOpenGPS
 
         public void FileSaveTracks()
         {
-            string dirField = fieldsDirectory + currentFieldDirectory + "\\";
-            string directoryName = Path.GetDirectoryName(dirField).ToString(CultureInfo.InvariantCulture);
+            string directoryName = Path.Combine(fieldsDirectory, currentFieldDirectory);
 
-            if ((directoryName.Length > 0) && (!Directory.Exists(directoryName)))
+            if (!string.IsNullOrEmpty(directoryName) && (!Directory.Exists(directoryName)))
             { Directory.CreateDirectory(directoryName); }
 
-            string filename = directoryName + "\\TrackLines.txt";
+            string filename = Path.Combine(directoryName, "TrackLines.txt");
 
             int cnt = trk.gArr.Count;
 
@@ -730,13 +724,12 @@ namespace AgOpenGPS
             trk.gArr?.Clear();
 
             //get the directory and make sure it exists, create if not
-            string dirField = fieldsDirectory + currentFieldDirectory + "\\";
-            string directoryName = Path.GetDirectoryName(dirField);
+            string directoryName = Path.Combine(fieldsDirectory, currentFieldDirectory);
 
             if ((directoryName.Length > 0) && (!Directory.Exists(directoryName)))
             { Directory.CreateDirectory(directoryName); }
 
-            string filename = directoryName + "\\TrackLines.txt";
+            string filename = Path.Combine(directoryName, "TrackLines.txt");
 
             if (!File.Exists(filename))
             {
@@ -831,13 +824,12 @@ namespace AgOpenGPS
 
         public void FileSaveCurveLines()
         {
-            string dirField = fieldsDirectory + currentFieldDirectory + "\\";
-            string directoryName = Path.GetDirectoryName(dirField).ToString(CultureInfo.InvariantCulture);
+            string directoryName = Path.Combine(fieldsDirectory, currentFieldDirectory);
 
-            if ((directoryName.Length > 0) && (!Directory.Exists(directoryName)))
+            if (!string.IsNullOrEmpty(directoryName) && (!Directory.Exists(directoryName)))
             { Directory.CreateDirectory(directoryName); }
 
-            string filename = directoryName + "\\CurveLines.txt";
+            string filename = Path.Combine(directoryName, "CurveLines.txt");
 
             int cnt = trk.gArr.Count;
 
@@ -889,13 +881,12 @@ namespace AgOpenGPS
         public void FileLoadCurveLines()
         {
             //get the directory and make sure it exists, create if not
-            string dirField = fieldsDirectory + currentFieldDirectory + "\\";
-            string directoryName = Path.GetDirectoryName(dirField);
+            string directoryName = Path.Combine(fieldsDirectory, currentFieldDirectory);
 
             if ((directoryName.Length > 0) && (!Directory.Exists(directoryName)))
             { Directory.CreateDirectory(directoryName); }
 
-            string filename = directoryName + "\\CurveLines.txt";
+            string filename = Path.Combine(directoryName, "CurveLines.txt");
 
             if (!File.Exists(filename))
             {
@@ -997,14 +988,13 @@ namespace AgOpenGPS
         public void FileSaveABLines()
         {
             //make sure at least a global blank AB Line file exists
-            string dirField = fieldsDirectory + currentFieldDirectory + "\\";
-            string directoryName = Path.GetDirectoryName(dirField).ToString(CultureInfo.InvariantCulture);
+            string directoryName = Path.Combine(fieldsDirectory, currentFieldDirectory);
 
             //get the file of previous AB Lines
-            if ((directoryName.Length > 0) && (!Directory.Exists(directoryName)))
+            if (!string.IsNullOrEmpty(directoryName) && (!Directory.Exists(directoryName)))
             { Directory.CreateDirectory(directoryName); }
 
-            string filename = directoryName + "\\ABLines.txt";
+            string filename = Path.Combine(directoryName, "ABLines.txt");
             int cnt = trk.gArr.Count;
 
             using (StreamWriter writer = new StreamWriter(filename, false))
@@ -1032,13 +1022,12 @@ namespace AgOpenGPS
         public void FileLoadABLines()
         {
             //make sure at least a global blank AB Line file exists
-            string dirField = fieldsDirectory + currentFieldDirectory + "\\";
-            string directoryName = Path.GetDirectoryName(dirField).ToString(CultureInfo.InvariantCulture);
+            string directoryName = Path.Combine(fieldsDirectory, currentFieldDirectory);
 
-            if ((directoryName.Length > 0) && (!Directory.Exists(directoryName)))
+            if (!string.IsNullOrEmpty(directoryName) && (!Directory.Exists(directoryName)))
             { Directory.CreateDirectory(directoryName); }
 
-            string filename = directoryName + "\\ABLines.txt";
+            string filename = Path.Combine(directoryName, "ABLines.txt");
 
             if (!File.Exists(filename))
             {
@@ -1115,7 +1104,7 @@ namespace AgOpenGPS
                 case "Resume":
                     {
                         //Either exit or update running save
-                        fileAndDirectory = fieldsDirectory + currentFieldDirectory + "\\Field.txt";
+                        fileAndDirectory = Path.Combine(fieldsDirectory, currentFieldDirectory, "Field.txt");
                         if (!File.Exists(fileAndDirectory)) fileAndDirectory = "Cancel";
                         break;
                     }
@@ -1233,7 +1222,7 @@ namespace AgOpenGPS
 
             
             //section patches
-            fileAndDirectory = fieldsDirectory + currentFieldDirectory + "\\Sections.txt";
+            fileAndDirectory = Path.Combine(fieldsDirectory, currentFieldDirectory, "Sections.txt");
             if (!File.Exists(fileAndDirectory))
             {
                 TimedMessageBox(2000, gStr.gsMissingSectionFile, gStr.gsButFieldIsLoaded);
@@ -1307,16 +1296,16 @@ namespace AgOpenGPS
                 //was old version prior to v4
                 if (isv3)
                 {
-                        //Append the current list to the field file
-                        using (StreamWriter writer = new StreamWriter((fieldsDirectory + currentFieldDirectory + "\\Sections.txt"), false))
-                        {
-                        }
+                    //Append the current list to the field file
+                    using (StreamWriter writer = new StreamWriter(Path.Combine(fieldsDirectory, currentFieldDirectory, "Sections.txt"), false))
+                    {
+                    }
                 }
             }
 
             // Contour points ----------------------------------------------------------------------------
 
-            fileAndDirectory = fieldsDirectory + currentFieldDirectory + "\\Contour.txt";
+            fileAndDirectory = Path.Combine(fieldsDirectory, currentFieldDirectory, "Contour.txt");
             if (!File.Exists(fileAndDirectory))
             {
                 TimedMessageBox(2000, gStr.gsMissingContourFile, gStr.gsButFieldIsLoaded);
@@ -1371,7 +1360,7 @@ namespace AgOpenGPS
             // Flags -------------------------------------------------------------------------------------------------
 
             //Either exit or update running save
-            fileAndDirectory = fieldsDirectory + currentFieldDirectory + "\\Flags.txt";
+            fileAndDirectory = Path.Combine(fieldsDirectory, currentFieldDirectory, "Flags.txt");
             if (!File.Exists(fileAndDirectory))
             {
                 TimedMessageBox(2000, gStr.gsMissingFlagsFile, gStr.gsButFieldIsLoaded);
@@ -1447,7 +1436,7 @@ namespace AgOpenGPS
 
             //Boundaries
             //Either exit or update running save
-            fileAndDirectory = fieldsDirectory + currentFieldDirectory + "\\Boundary.txt";
+            fileAndDirectory = Path.Combine(fieldsDirectory, currentFieldDirectory, "Boundary.txt");
             if (!File.Exists(fileAndDirectory))
             {
                 TimedMessageBox(2000, gStr.gsMissingBoundaryFile, gStr.gsButFieldIsLoaded);
@@ -1541,7 +1530,7 @@ namespace AgOpenGPS
             }
 
             // Headland  -------------------------------------------------------------------------------------------------
-            fileAndDirectory = fieldsDirectory + currentFieldDirectory + "\\Headland.txt";
+            fileAndDirectory = Path.Combine(fieldsDirectory, currentFieldDirectory, "Headland.txt");
 
             if (File.Exists(fileAndDirectory))
             {
@@ -1609,7 +1598,7 @@ namespace AgOpenGPS
             btnHydLift.Visible = (((sett & 2) == 2) && bnd.isHeadlandOn); 
 
             //trams ---------------------------------------------------------------------------------
-            fileAndDirectory = fieldsDirectory + currentFieldDirectory + "\\Tram.txt";
+            fileAndDirectory = Path.Combine(fieldsDirectory, currentFieldDirectory, "Tram.txt");
 
             tram.tramBndOuterArr?.Clear();
             tram.tramBndInnerArr?.Clear();
@@ -1715,7 +1704,7 @@ namespace AgOpenGPS
             //}
 
             //Recorded Path
-            fileAndDirectory = fieldsDirectory + currentFieldDirectory + "\\RecPath.txt";
+            fileAndDirectory = Path.Combine(fieldsDirectory, currentFieldDirectory, "RecPath.txt");
             if (File.Exists(fileAndDirectory))
             {
                 using (StreamReader reader = new StreamReader(fileAndDirectory))
@@ -1762,7 +1751,7 @@ namespace AgOpenGPS
             worldGrid.isGeoMap = false;
 
             //Back Image
-            fileAndDirectory = fieldsDirectory + currentFieldDirectory + "\\BackPic.txt";
+            fileAndDirectory = Path.Combine(fieldsDirectory, currentFieldDirectory, "BackPic.txt");
             if (File.Exists(fileAndDirectory))
             {
                 using (StreamReader reader = new StreamReader(fileAndDirectory))
@@ -1791,7 +1780,7 @@ namespace AgOpenGPS
 
                     if (worldGrid.isGeoMap)
                     {
-                        fileAndDirectory = fieldsDirectory + currentFieldDirectory + "\\BackPic.png";
+                        fileAndDirectory = Path.Combine(fieldsDirectory, currentFieldDirectory, "BackPic.png");
                         if (File.Exists(fileAndDirectory))
                         {
                             var bitmap = new Bitmap(Image.FromFile(fileAndDirectory));
@@ -1831,18 +1820,17 @@ namespace AgOpenGPS
                 TimedMessageBox(3000, gStr.gsFieldNotOpen, gStr.gsCreateNewField);
                 return;
             }
-            string myFileName, dirField;
+            string myFileName;
 
             //get the directory and make sure it exists, create if not
-            dirField = fieldsDirectory + currentFieldDirectory + "\\";
-            string directoryName = Path.GetDirectoryName(dirField);
+            string directoryName = Path.Combine(fieldsDirectory, currentFieldDirectory);
 
             if ((directoryName.Length > 0) && (!Directory.Exists(directoryName)))
             { Directory.CreateDirectory(directoryName); }
 
             myFileName = "Field.txt";
 
-            using (StreamWriter writer = new StreamWriter(dirField + myFileName))
+            using (StreamWriter writer = new StreamWriter(Path.Combine(directoryName, myFileName)))
             {
                 //Write out the date
                 writer.WriteLine(DateTime.Now.ToString("yyyy-MMMM-dd hh:mm:ss tt", CultureInfo.InvariantCulture));
@@ -1877,18 +1865,17 @@ namespace AgOpenGPS
             //    return;
             //}
 
-            string myFileName, dirField;
+            string myFileName;
 
             //get the directory and make sure it exists, create if not
-            dirField = fieldsDirectory + currentFieldDirectory + "\\";
-            string directoryName = Path.GetDirectoryName(dirField);
+            string directoryName = Path.Combine(fieldsDirectory, currentFieldDirectory);
 
             if ((directoryName.Length > 0) && (!Directory.Exists(directoryName)))
             { Directory.CreateDirectory(directoryName); }
 
             myFileName = "Elevation.txt";
 
-            using (StreamWriter writer = new StreamWriter(dirField + myFileName))
+            using (StreamWriter writer = new StreamWriter(Path.Combine(directoryName, myFileName)))
             {
                 //Write out the date
                 writer.WriteLine(DateTime.Now.ToString("yyyy-MMMM-dd hh:mm:ss tt", CultureInfo.InvariantCulture));
@@ -1917,7 +1904,7 @@ namespace AgOpenGPS
             if (patchSaveList.Count() > 0)
             {
                 //Append the current list to the field file
-                using (StreamWriter writer = new StreamWriter((fieldsDirectory + currentFieldDirectory + "\\Sections.txt"), true))
+                using (StreamWriter writer = new StreamWriter(Path.Combine(fieldsDirectory, currentFieldDirectory, "Sections.txt"), true))
                 {
                     //for each patch, write out the list of triangles to the file
                     foreach (var triList in patchSaveList)
@@ -1945,16 +1932,15 @@ namespace AgOpenGPS
             //10.1728031317344,0.723157039771303 -easting, northing
 
             //get the directory and make sure it exists, create if not
-            string dirField = fieldsDirectory + currentFieldDirectory + "\\";
+            string directoryName = Path.Combine(fieldsDirectory, currentFieldDirectory);
 
-            string directoryName = Path.GetDirectoryName(dirField);
             if ((directoryName.Length > 0) && (!Directory.Exists(directoryName)))
             { Directory.CreateDirectory(directoryName); }
 
             string myFileName = "Sections.txt";
 
             //write out the file
-            using (StreamWriter writer = new StreamWriter(dirField + myFileName))
+            using (StreamWriter writer = new StreamWriter(Path.Combine(directoryName, myFileName)))
             {
                 //write paths # of sections
                 //writer.WriteLine("$Sectionsv4");
@@ -1968,16 +1954,15 @@ namespace AgOpenGPS
             //10.1728031317344,0.723157039771303 -easting, northing
 
             //get the directory and make sure it exists, create if not
-            string dirField = fieldsDirectory + currentFieldDirectory + "\\";
+            string directoryName = Path.Combine(fieldsDirectory, currentFieldDirectory);
 
-            string directoryName = Path.GetDirectoryName(dirField);
             if ((directoryName.Length > 0) && (!Directory.Exists(directoryName)))
             { Directory.CreateDirectory(directoryName); }
 
             string myFileName = "Boundary.txt";
 
             //write out the file
-            using (StreamWriter writer = new StreamWriter(dirField + myFileName))
+            using (StreamWriter writer = new StreamWriter(Path.Combine(directoryName, myFileName)))
             {
                 //write paths # of sections
                 writer.WriteLine("$Boundary");
@@ -1992,16 +1977,15 @@ namespace AgOpenGPS
             //10.1728031317344,0.723157039771303 -easting, northing
 
             //get the directory and make sure it exists, create if not
-            string dirField = fieldsDirectory + currentFieldDirectory + "\\";
+            string directoryName = Path.Combine(fieldsDirectory, currentFieldDirectory);
 
-            string directoryName = Path.GetDirectoryName(dirField);
             if ((directoryName.Length > 0) && (!Directory.Exists(directoryName)))
             { Directory.CreateDirectory(directoryName); }
 
             string myFileName = "Flags.txt";
 
             //write out the file
-            using (StreamWriter writer = new StreamWriter(dirField + myFileName))
+            using (StreamWriter writer = new StreamWriter(Path.Combine(directoryName, myFileName)))
             {
                 //write paths # of sections
                 //writer.WriteLine("$Sectionsv4");
@@ -2015,16 +1999,15 @@ namespace AgOpenGPS
             //64.697,0.168,-21.654,0 - east, heading, north, altitude
 
             //get the directory and make sure it exists, create if not
-            string dirField = fieldsDirectory + currentFieldDirectory + "\\";
+            string directoryName = Path.Combine(fieldsDirectory, currentFieldDirectory);
 
-            string directoryName = Path.GetDirectoryName(dirField);
             if ((directoryName.Length > 0) && (!Directory.Exists(directoryName)))
             { Directory.CreateDirectory(directoryName); }
 
             string myFileName = "Contour.txt";
 
             //write out the file
-            using (StreamWriter writer = new StreamWriter(dirField + myFileName))
+            using (StreamWriter writer = new StreamWriter(Path.Combine(directoryName, myFileName)))
             {
                 writer.WriteLine("$Contour");
             }
@@ -2040,7 +2023,7 @@ namespace AgOpenGPS
             if (contourSaveList.Count() > 0)
             {
                 //Append the current list to the field file
-                using (StreamWriter writer = new StreamWriter((fieldsDirectory + currentFieldDirectory + "\\Contour.txt"), true))
+                using (StreamWriter writer = new StreamWriter(Path.Combine(fieldsDirectory, currentFieldDirectory, "Contour.txt"), true))
                 {
 
                     //for every new chunk of patch in the whole section
@@ -2068,14 +2051,13 @@ namespace AgOpenGPS
         public void FileSaveBoundary()
         {
             //get the directory and make sure it exists, create if not
-            string dirField = fieldsDirectory + currentFieldDirectory + "\\";
+            string directoryName = Path.Combine(fieldsDirectory, currentFieldDirectory);
 
-            string directoryName = Path.GetDirectoryName(dirField);
             if ((directoryName.Length > 0) && (!Directory.Exists(directoryName)))
             { Directory.CreateDirectory(directoryName); }
 
             //write out the file
-            using (StreamWriter writer = new StreamWriter(dirField + "Boundary.Txt"))
+            using (StreamWriter writer = new StreamWriter(Path.Combine(directoryName, "Boundary.Txt")))
             {
                 writer.WriteLine("$Boundary");
                 for (int i = 0; i < bnd.bndList.Count; i++)
@@ -2099,14 +2081,13 @@ namespace AgOpenGPS
         public void FileSaveTram()
         {
             //get the directory and make sure it exists, create if not
-            string dirField = fieldsDirectory + currentFieldDirectory + "\\";
+            string directoryName = Path.Combine(fieldsDirectory, currentFieldDirectory);
 
-            string directoryName = Path.GetDirectoryName(dirField);
             if ((directoryName.Length > 0) && (!Directory.Exists(directoryName)))
             { Directory.CreateDirectory(directoryName); }
 
             //write out the file
-            using (StreamWriter writer = new StreamWriter(dirField + "Tram.Txt"))
+            using (StreamWriter writer = new StreamWriter(Path.Combine(directoryName, "Tram.Txt")))
             {
                 writer.WriteLine("$Tram");
 
@@ -2158,14 +2139,13 @@ namespace AgOpenGPS
         public void FileSaveBackPic()
         {
             //get the directory and make sure it exists, create if not
-            string dirField = fieldsDirectory + currentFieldDirectory + "\\";
+            string directoryName = Path.Combine(fieldsDirectory, currentFieldDirectory);
 
-            string directoryName = Path.GetDirectoryName(dirField);
             if ((directoryName.Length > 0) && (!Directory.Exists(directoryName)))
             { Directory.CreateDirectory(directoryName); }
 
             //write out the file
-            using (StreamWriter writer = new StreamWriter(dirField + "BackPic.Txt"))
+            using (StreamWriter writer = new StreamWriter(Path.Combine(directoryName, "BackPic.Txt")))
             {
                 writer.WriteLine("$BackPic");
                 //outer track of outer boundary tram
@@ -2192,14 +2172,13 @@ namespace AgOpenGPS
         public void FileSaveHeadland()
         {
             //get the directory and make sure it exists, create if not
-            string dirField = fieldsDirectory + currentFieldDirectory + "\\";
+            string directoryName = Path.Combine(fieldsDirectory, currentFieldDirectory);
 
-            string directoryName = Path.GetDirectoryName(dirField);
             if ((directoryName.Length > 0) && (!Directory.Exists(directoryName)))
             { Directory.CreateDirectory(directoryName); }
 
             //write out the file
-            using (StreamWriter writer = new StreamWriter(dirField + "Headland.Txt"))
+            using (StreamWriter writer = new StreamWriter(Path.Combine(directoryName, "Headland.Txt")))
             {
                 writer.WriteLine("$Headland");
 
@@ -2224,16 +2203,15 @@ namespace AgOpenGPS
         public void FileCreateRecPath()
         {
             //get the directory and make sure it exists, create if not
-            string dirField = fieldsDirectory + currentFieldDirectory + "\\";
+            string directoryName = Path.Combine(fieldsDirectory, currentFieldDirectory);
 
-            string directoryName = Path.GetDirectoryName(dirField);
             if ((directoryName.Length > 0) && (!Directory.Exists(directoryName)))
             { Directory.CreateDirectory(directoryName); }
 
             string myFileName = "RecPath.txt";
 
             //write out the file
-            using (StreamWriter writer = new StreamWriter(dirField + myFileName))
+            using (StreamWriter writer = new StreamWriter(Path.Combine(directoryName, myFileName)))
             {
                 //write paths # of sections
                 writer.WriteLine("$RecPath");
@@ -2245,9 +2223,8 @@ namespace AgOpenGPS
         public void FileSaveRecPath(string name = "RecPath.Txt")
         {
             //get the directory and make sure it exists, create if not
-            string dirField = fieldsDirectory + currentFieldDirectory + "\\";
+            string directoryName = Path.Combine(fieldsDirectory, currentFieldDirectory);
 
-            string directoryName = Path.GetDirectoryName(dirField);
             if ((directoryName.Length > 0) && (!Directory.Exists(directoryName)))
             { Directory.CreateDirectory(directoryName); }
 
@@ -2255,7 +2232,7 @@ namespace AgOpenGPS
             //if (!File.Exists(fileAndDirectory)) FileCreateRecPath();
 
             //write out the file
-            using (StreamWriter writer = new StreamWriter((dirField + name)))
+            using (StreamWriter writer = new StreamWriter(Path.Combine(directoryName, name)))
             {
                 writer.WriteLine("$RecPath");
                 writer.WriteLine(recPath.recList.Count.ToString(CultureInfo.InvariantCulture));
@@ -2280,7 +2257,7 @@ namespace AgOpenGPS
         {
             string line;
             //Recorded Path
-            string fileAndDirectory = fieldsDirectory + currentFieldDirectory + "\\RecPath.txt";
+            string fileAndDirectory = Path.Combine(fieldsDirectory, currentFieldDirectory, "RecPath.txt");
             if (File.Exists(fileAndDirectory))
             {
                 using (StreamReader reader = new StreamReader(fileAndDirectory))
@@ -2332,14 +2309,13 @@ namespace AgOpenGPS
             //533172,5927719,12 - offset easting, northing, zone
 
             //get the directory and make sure it exists, create if not
-            string dirField = fieldsDirectory + currentFieldDirectory + "\\";
+            string directoryName = Path.Combine(fieldsDirectory, currentFieldDirectory);
 
-            string directoryName = Path.GetDirectoryName(dirField);
             if ((directoryName.Length > 0) && (!Directory.Exists(directoryName)))
             { Directory.CreateDirectory(directoryName); }
 
             //use Streamwriter to create and overwrite existing flag file
-            using (StreamWriter writer = new StreamWriter(dirField + "Flags.txt"))
+            using (StreamWriter writer = new StreamWriter(Path.Combine(directoryName, "Flags.txt")))
             {
                 try
                 {
@@ -2468,7 +2444,7 @@ namespace AgOpenGPS
 
         public void FileSaveSystemEvents()
         {
-            using (StreamWriter writer = new StreamWriter(logsDirectory + "zSystemEventsLog_log.txt", true))
+            using (StreamWriter writer = new StreamWriter(Path.Combine(logsDirectory, "zSystemEventsLog_log.txt"), true))
             {
                 writer.Write(sbSystemEvents);
             }
@@ -2477,7 +2453,7 @@ namespace AgOpenGPS
         //save nmea sentences
         public void FileSaveElevation()
         {
-            using (StreamWriter writer = new StreamWriter((fieldsDirectory + currentFieldDirectory + "\\Elevation.txt"), true))
+            using (StreamWriter writer = new StreamWriter(Path.Combine(fieldsDirectory, currentFieldDirectory, "Elevation.txt"), true))
             {
                 writer.Write(sbGrid.ToString());
             }
@@ -2493,16 +2469,15 @@ namespace AgOpenGPS
             pn.ConvertLocalToWGS84(flagPts[flagNumber - 1].northing, flagPts[flagNumber - 1].easting, out lat, out lon);
 
             //get the directory and make sure it exists, create if not
-            string dirField = fieldsDirectory + currentFieldDirectory + "\\";
+            string directoryName = Path.Combine(fieldsDirectory, currentFieldDirectory);
 
-            string directoryName = Path.GetDirectoryName(dirField);
             if ((directoryName.Length > 0) && (!Directory.Exists(directoryName)))
             { Directory.CreateDirectory(directoryName); }
 
             string myFileName;
             myFileName = "Flag.kml";
 
-            using (StreamWriter writer = new StreamWriter(dirField + myFileName))
+            using (StreamWriter writer = new StreamWriter(Path.Combine(directoryName, myFileName)))
             {
                 //match new fix to current position
 
@@ -2539,16 +2514,15 @@ namespace AgOpenGPS
         {
 
             //get the directory and make sure it exists, create if not
-            string dirField = fieldsDirectory + currentFieldDirectory + "\\";
+            string directoryName = Path.Combine(fieldsDirectory, currentFieldDirectory);
 
-            string directoryName = Path.GetDirectoryName(dirField);
             if ((directoryName.Length > 0) && (!Directory.Exists(directoryName)))
             { Directory.CreateDirectory(directoryName); }
 
             string myFileName;
             myFileName = "Flag.kml";
 
-            using (StreamWriter writer = new StreamWriter(dirField + myFileName))
+            using (StreamWriter writer = new StreamWriter(Path.Combine(directoryName, myFileName)))
             {
                 //match new fix to current position
 
@@ -2583,14 +2557,13 @@ namespace AgOpenGPS
         public void FileMakeKMLFromCurrentPosition(double lat, double lon)
         {
             //get the directory and make sure it exists, create if not
-            string dirField = fieldsDirectory + currentFieldDirectory + "\\";
+            string directoryName = Path.Combine(fieldsDirectory, currentFieldDirectory);
 
-            string directoryName = Path.GetDirectoryName(dirField);
             if ((directoryName.Length > 0) && (!Directory.Exists(directoryName)))
             { Directory.CreateDirectory(directoryName); }
 
 
-            using (StreamWriter writer = new StreamWriter(dirField + "CurrentPosition.kml"))
+            using (StreamWriter writer = new StreamWriter(Path.Combine(directoryName, "CurrentPosition.kml")))
             {
 
                 writer.WriteLine(@"<?xml version=""1.0"" encoding=""UTF-8""?>     ");
@@ -2619,16 +2592,15 @@ namespace AgOpenGPS
         public void ExportFieldAs_KML()
         {
             //get the directory and make sure it exists, create if not
-            string dirField = fieldsDirectory + currentFieldDirectory + "\\";
+            string directoryName = Path.Combine(fieldsDirectory, currentFieldDirectory);
 
-            string directoryName = Path.GetDirectoryName(dirField);
             if ((directoryName.Length > 0) && (!Directory.Exists(directoryName)))
             { Directory.CreateDirectory(directoryName); }
 
             string myFileName;
             myFileName = "Field.kml";
 
-            XmlTextWriter kml = new XmlTextWriter(dirField + myFileName, Encoding.UTF8);
+            XmlTextWriter kml = new XmlTextWriter(Path.Combine(directoryName, myFileName), Encoding.UTF8);
 
             kml.Formatting = Formatting.Indented;
             kml.Indentation = 3;
@@ -2936,9 +2908,8 @@ namespace AgOpenGPS
         {
 
             //get the directory and make sure it exists, create if not
-            string dirAllField = fieldsDirectory + "\\";
+            string directoryName = fieldsDirectory;
 
-            string directoryName = Path.GetDirectoryName(dirAllField);
             if ((directoryName.Length > 0) && (!Directory.Exists(directoryName)))
             {
                 return; //We have no fields to aggregate.
@@ -2947,7 +2918,7 @@ namespace AgOpenGPS
             string myFileName;
             myFileName = "AllFields.kml";
 
-            XmlTextWriter kml = new XmlTextWriter(dirAllField + myFileName, Encoding.UTF8);
+            XmlTextWriter kml = new XmlTextWriter(Path.Combine(directoryName, myFileName), Encoding.UTF8);
 
             kml.Formatting = Formatting.Indented;
             kml.Indentation = 3;
@@ -2959,13 +2930,13 @@ namespace AgOpenGPS
             foreach(String dir in Directory.EnumerateDirectories(directoryName).OrderBy(d => new DirectoryInfo(d).Name).ToArray())
             //loop
             {
-                if (!File.Exists(dir + "\\" + "Field.kml")) continue;
+                if (!File.Exists(Path.Combine(dir, "Field.kml"))) continue;
 
                 directoryName = Path.GetFileName(dir);
                 kml.WriteStartElement("Folder");
                 kml.WriteElementString("name", directoryName);
 
-                var lines = File.ReadAllLines(dir + "\\" + "Field.kml");
+                var lines = File.ReadAllLines(Path.Combine(dir, "Field.kml"));
                 LinkedList<string> linebuffer = new LinkedList<string>();
                 for( var i = 3; i < lines.Length-2; i++)  //We want to skip the first 3 and last 2 lines
                 {

--- a/SourceCode/GPS/Forms/Settings/ConfigVehicle.Designer.cs
+++ b/SourceCode/GPS/Forms/Settings/ConfigVehicle.Designer.cs
@@ -21,7 +21,7 @@ namespace AgOpenGPS
         {
             if (tboxVehicleNameSave.Text.Trim().Length > 0)
             {
-                SettingsIO.ExportAll(mf.vehiclesDirectory + tboxVehicleNameSave.Text.Trim() + ".XML");
+                SettingsIO.ExportAll(Path.Combine(mf.vehiclesDirectory, tboxVehicleNameSave.Text.Trim() + ".XML"));
 
                 mf.vehicleFileName = tboxVehicleNameSave.Text.Trim();
                 Properties.Settings.Default.setVehicle_vehicleName = mf.vehicleFileName;
@@ -50,7 +50,7 @@ namespace AgOpenGPS
             if (!mf.isJobStarted)
             {
                 //save current vehicle
-                SettingsIO.ExportAll(mf.vehiclesDirectory + mf.vehicleFileName + ".XML");
+                SettingsIO.ExportAll(Path.Combine(mf.vehiclesDirectory, mf.vehicleFileName + ".XML"));
 
                 if (lvVehicles.SelectedItems.Count > 0)
                 {
@@ -65,7 +65,7 @@ namespace AgOpenGPS
 
                         if (result3 == DialogResult.Yes)
                         {
-                            bool success = SettingsIO.ImportAll(mf.vehiclesDirectory + lvVehicles.SelectedItems[0].SubItems[0].Text + ".XML");
+                            bool success = SettingsIO.ImportAll(Path.Combine(mf.vehiclesDirectory, lvVehicles.SelectedItems[0].SubItems[0].Text + ".XML"));
                             if (!success) return;
 
                             mf.vehicleFileName = lvVehicles.SelectedItems[0].SubItems[0].Text;
@@ -173,7 +173,7 @@ namespace AgOpenGPS
                             MessageBoxDefaultButton.Button2);
                             if (result3 == DialogResult.Yes)
                             {
-                                File.Delete(mf.vehiclesDirectory + lvVehicles.SelectedItems[0].SubItems[0].Text + ".XML");
+                                File.Delete(Path.Combine(mf.vehiclesDirectory, lvVehicles.SelectedItems[0].SubItems[0].Text + ".XML"));
                             }
                         }
                         else
@@ -406,7 +406,7 @@ namespace AgOpenGPS
                         MessageBoxDefaultButton.Button2);
                     if (result3 == DialogResult.Yes)
                     {
-                        SettingsIO.ExportAll(mf.vehiclesDirectory + lvVehicles.SelectedItems[0].SubItems[0].Text + ".XML");
+                        SettingsIO.ExportAll(Path.Combine(mf.vehiclesDirectory, lvVehicles.SelectedItems[0].SubItems[0].Text + ".XML"));
                     }
                     UpdateVehicleListView();
                 }

--- a/SourceCode/GPS/Forms/Settings/FormAllSettings.cs
+++ b/SourceCode/GPS/Forms/Settings/FormAllSettings.cs
@@ -5,6 +5,7 @@ using System;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.Globalization;
+using System.IO;
 using System.Reflection.Emit;
 using System.Windows.Forms;
 
@@ -166,7 +167,7 @@ namespace AgOpenGPS
         {
             Bitmap bm = new Bitmap(this.Width, this.Height);
             this.DrawToBitmap(bm, new Rectangle(0, 0, this.Width, this.Height));
-            bm.Save(mf.baseDirectory + "//AllSet.PNG", ImageFormat.Png);
+            bm.Save(Path.Combine(mf.baseDirectory, "AllSet.PNG"), ImageFormat.Png);
             System.Diagnostics.Process.Start("explorer.exe", mf.baseDirectory);
             mf.LogEventWriter("View All Settings to PNG");
             Close();

--- a/SourceCode/GPS/Forms/Settings/FormButtonsRightPanel.cs
+++ b/SourceCode/GPS/Forms/Settings/FormButtonsRightPanel.cs
@@ -212,9 +212,7 @@ namespace AgOpenGPS
         {
             Process[] processName = Process.GetProcessesByName("BobsYourUncle");
             //Start application here
-            DirectoryInfo di = new DirectoryInfo(Application.StartupPath);
-            string strPath = di.ToString();
-            strPath += "\\Buttons.mp4";
+            string strPath = Path.Combine(Application.StartupPath, "Buttons.mp4");
 
             try
             {

--- a/SourceCode/GPS/Forms/Settings/FormConfig.cs
+++ b/SourceCode/GPS/Forms/Settings/FormConfig.cs
@@ -4,6 +4,7 @@ using AgOpenGPS.Culture;
 using Microsoft.Win32;
 using System;
 using System.Drawing;
+using System.IO;
 using System.Windows.Forms;
 
 namespace AgOpenGPS
@@ -136,7 +137,7 @@ namespace AgOpenGPS
             mf.LoadSettings();
 
             //save current vehicle
-            SettingsIO.ExportAll(mf.vehiclesDirectory + mf.vehicleFileName + ".XML");
+            SettingsIO.ExportAll(Path.Combine(mf.vehiclesDirectory, mf.vehicleFileName + ".XML"));
         }
 
         private void FixMinMaxSpinners()

--- a/SourceCode/GPS/Forms/Settings/FormSteer.cs
+++ b/SourceCode/GPS/Forms/Settings/FormSteer.cs
@@ -3,6 +3,7 @@ using AgOpenGPS.Properties;
 using System;
 using System.Diagnostics.Eventing.Reader;
 using System.Drawing;
+using System.IO;
 using System.Windows.Forms;
 
 namespace AgOpenGPS
@@ -428,7 +429,7 @@ namespace AgOpenGPS
             Properties.Settings.Default.Save();
 
             //save current vehicle
-            SettingsIO.ExportAll(mf.vehiclesDirectory + mf.vehicleFileName + ".XML");
+            SettingsIO.ExportAll(Path.Combine(mf.vehiclesDirectory, mf.vehicleFileName + ".XML"));
         }
 
         private void tabSettings_Enter(object sender, EventArgs e)
@@ -630,7 +631,7 @@ namespace AgOpenGPS
                 Properties.Settings.Default.Save();
 
                 //save current vehicle
-                SettingsIO.ExportAll(mf.vehiclesDirectory + mf.vehicleFileName + ".XML");
+                SettingsIO.ExportAll(Path.Combine(mf.vehiclesDirectory, mf.vehicleFileName + ".XML"));
 
                 FormSteer_Load(this, e);
 

--- a/SourceCode/GPS/Forms/Settings/FormSteerWiz.cs
+++ b/SourceCode/GPS/Forms/Settings/FormSteerWiz.cs
@@ -1,6 +1,7 @@
 ﻿using AgOpenGPS.Culture;
 using System;
 using System.Drawing;
+using System.IO;
 using System.Windows.Forms;
 
 namespace AgOpenGPS
@@ -249,7 +250,7 @@ namespace AgOpenGPS
             Properties.Settings.Default.Save();
 
             //save current vehicle
-            SettingsIO.ExportAll(mf.vehiclesDirectory + mf.vehicleFileName + ".XML");
+            SettingsIO.ExportAll(Path.Combine(mf.vehiclesDirectory, mf.vehicleFileName + ".XML"));
         }
 
         private void Timer1_Tick(object sender, EventArgs e)
@@ -601,7 +602,7 @@ namespace AgOpenGPS
             counter251 = 2;
 
             //save current vehicle
-            SettingsIO.ExportAll(mf.vehiclesDirectory + mf.vehicleFileName + ".XML");
+            SettingsIO.ExportAll(Path.Combine(mf.vehiclesDirectory, mf.vehicleFileName + ".XML"));
 
             FormSteer_Load(this, e);
         }


### PR DESCRIPTION
By using [`Path.Combine`](https://learn.microsoft.com/en-us/dotnet/api/system.io.path.combine) instead of string concatenations, we don't rely on Windows path separator (`\`) and would be compatible with platforms using `/` as well.